### PR TITLE
allow multiple schemas for given statements

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -25,8 +25,8 @@ def get_mvd(ifc_file):
         detected_mvd = ifc_file.header.file_description.description[0].split(" ", 1)[1]
         detected_mvd = detected_mvd[1:-1]
     except:
-        detected_mvd = None
-    return detected_mvd
+        detected_mvd = ''
+    return detected_mvd.lower()
 
 def get_inst_attributes(dc):
     if hasattr(dc, 'inst'):
@@ -167,14 +167,15 @@ def step_impl(context, attribute, value):
 
 @given('A file with {field} "{values}"')
 def step_impl(context, field, values):
-    values = list(values.replace('"', "").split(', '))
+    values = list(map(str.lower, map(lambda s: s.strip('"'), values.split(' or '))))
     if field == "Model View Definition":
-        applicable = any([get_mvd(context.model) == value for value in values])
+        applicable = get_mvd(context.model) in values
     elif field == "Schema Identifier":
-        applicable = any([context.model.schema.lower() == value.lower() for value in values])
+        applicable = context.model.schema.lower() in values
     else:
         raise NotImplementedError(f'A file with "{field}" is not implemented')
 
+    context.applicable = getattr(context, 'applicable', True) and applicable
 
 @then('There shall be {constraint} {num:d} instance(s) of {entity}')
 def step_impl(context, constraint, num, entity):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -25,8 +25,8 @@ def get_mvd(ifc_file):
         detected_mvd = ifc_file.header.file_description.description[0].split(" ", 1)[1]
         detected_mvd = detected_mvd[1:-1]
     except:
-        detected_mvd = ''
-    return detected_mvd.lower()
+        detected_mvd = None
+    return detected_mvd
 
 def get_inst_attributes(dc):
     if hasattr(dc, 'inst'):
@@ -164,12 +164,12 @@ def step_impl(context, attribute, value):
         filter(lambda inst: getattr(inst, attribute) == value, context.instances)
     )
 
-
 @given('A file with {field} "{values}"')
 def step_impl(context, field, values):
     values = list(map(str.lower, map(lambda s: s.strip('"'), values.split(' or '))))
     if field == "Model View Definition":
-        applicable = get_mvd(context.model) in values
+        conditional_lowercase = lambda s: s.lower() if s else None
+        applicable = conditional_lowercase(get_mvd(context.model)) in values
     elif field == "Schema Identifier":
         applicable = context.model.schema.lower() in values
     else:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -165,16 +165,15 @@ def step_impl(context, attribute, value):
     )
 
 
-@given('A file with {field} "{value}"')
-def step_impl(context, field, value):
+@given('A file with {field} "{values}"')
+def step_impl(context, field, values):
+    values = list(values.replace('"', "").split(', '))
     if field == "Model View Definition":
-        applicable = get_mvd(context.model) == value
+        applicable = any([get_mvd(context.model) == value for value in values])
     elif field == "Schema Identifier":
-        applicable = context.model.schema.lower() == value.lower()
+        applicable = any([context.model.schema.lower() == value.lower() for value in values])
     else:
         raise NotImplementedError(f'A file with "{field}" is not implemented')
-
-    context.applicable = getattr(context, 'applicable', True) and applicable
 
 
 @then('There shall be {constraint} {num:d} instance(s) of {entity}')


### PR DESCRIPTION
As discussed, it might be useful to be able to allow for multiple schemas. In case a rule is applicable to more schemas or when new schemas are added in the future. It will still work when only one schema is allowed. 

As an example, it can be implemented in a gherkin feature given statement like this:
Given A file with Schema Identifier "IFC4X3", "IFC4X3_ADD1"
