### PR TITLE
[X - Experiment] Pyparsing and using brackets/extra symbols in gherkin statements

### DIFF
--- a/features/ALB001_Alignment-in-spatial-structure.feature
+++ b/features/ALB001_Alignment-in-spatial-structure.feature
@@ -7,4 +7,4 @@ The rule verifies, that each IfcAlignment is contained in an IfcSite.
 
       Given A file with Schema Identifier "IFC4X3"
       And An IfcAlignment
-      Then Each IfcAlignment must be directly contained in IfcSite
+      Then Each "IfcAlignment" must be contained directly in "IfcSite"

--- a/features/ALB002_Alignment-layout.feature
+++ b/features/ALB002_Alignment-layout.feature
@@ -6,26 +6,26 @@ Feature: ALB002 - Alignment Layout
 
       Given A file with Schema Identifier "IFC4X3" or "IFC4X3_TC1" or "IFC4X3_ADD1"
 
-      Then Each IfcAlignment must be nested by exactly 1 instance(s) of IfcAlignmentHorizontal
-       And Each IfcAlignment must be nested by at most 1 instance(s) of IfcAlignmentVertical
-       And Each IfcAlignment must be nested by at most 1 instance(s) of IfcAlignmentCant  
+      Then Each "IfcAlignment" must be nested by exactly 1 instance(s) of "IfcAlignmentHorizontal"
+       And Each "IfcAlignment" must be nested by at most 1 instance(s) of "IfcAlignmentVertical"
+       And Each "IfcAlignment" must be nested by at most 1 instance(s) of "IfcAlignmentCant"  
   
     
   Scenario: Agreement on attributes being nested within a decomposition relationship
 
       Given A file with Schema Identifier "IFC4X3" or "IFC4X3_TC1" or "IFC4X3_ADD1"
 
-      Then Each IfcAlignmentHorizontal must nest only 1 instance(s) of IfcAlignment
-       And Each IfcAlignmentVertical must nest only 1 instance(s) of IfcAlignment
-       And Each IfcAlignmentCant must nest only 1 instance(s) of IfcAlignment
+      Then Each "IfcAlignmentHorizontal" must nest only 1 instance(s) of "IfcAlignment"
+       And Each "IfcAlignmentVertical" must nest only 1 instance(s) of "IfcAlignment"
+       And Each "IfcAlignmentCant" must nest only 1 instance(s) of "IfcAlignment"
   
   Scenario: Agreement of structure of alignments segments
 
       Given A file with Schema Identifier "IFC4X3" or "IFC4X3_TC1" or "IFC4X3_ADD1"
 
-      Then Each IfcAlignmentHorizontal is nested by a list of only instance(s) of IfcAlignmentSegment
-      Then Each IfcAlignmentVertical is nested by a list of only instance(s) of IfcAlignmentSegment
-      Then Each IfcAlignmentCant is nested by a list of only instance(s) of IfcAlignmentSegment
+      Then Each "IfcAlignmentHorizontal" is nested by a list of only instance(s) of "IfcAlignmentSegment"
+      Then Each "IfcAlignmentVertical" is nested by a list of only instance(s) of "IfcAlignmentSegment"
+      Then Each "IfcAlignmentCant" is nested by a list of only instance(s) of "IfcAlignmentSegment"
 
 
   Scenario: Agreement of the segments of the horizontal alignment

--- a/features/ALB003_Alignment-directions.feature
+++ b/features/ALB003_Alignment-directions.feature
@@ -11,6 +11,5 @@ Feature: ALB003 - Alignment Nesting
 
       Given a file with Schema Identifier "IFC4X3"
 
-       Then Each IfcAlignment may be nested by only the following entities: IfcAlignmentHorizontal, IfcAlignmentVertical, IfcAlignmentCant, IfcReferent
-  
+       Then Each "IfcAlignment" may be nested by only the following entities: "IfcAlignmentHorizontal", "IfcAlignmentVertical", "IfcAlignmentCant", "IfcReferent"
     

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 import pyparsing
 
 from behave import *
-from pyparsing import Word, alphas, ZeroOrMore, delimitedList, Group, oneOf, Literal, Or, nums, Optional, OneOrMore
+from pyparsing import Word, alphas, ZeroOrMore, delimitedList, Group, oneOf, Literal, Or, nums, Optional, OneOrMore, LineEnd, CaselessKeyword
 
 
 def instance_converter(kv_pairs):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -17,8 +17,7 @@ from dataclasses import dataclass, field
 import pyparsing
 
 from behave import *
-import pyparsing
-from pyparsing import *
+from pyparsing import Word, alphas, ZeroOrMore, delimitedList, Group, oneOf, Literal, Or, nums, Optional, OneOrMore
 
 
 def instance_converter(kv_pairs):


### PR DESCRIPTION
There were two overlapping questions, (1) whether we should use brackets or extra symbols in gherkin statements and  (2) whether to use leverage pyparsing as an additional custom parsing tool. There is a certain tradeoff between the two approaches we should be cautious of. 
When the solution is leaning too much towards custom parsing, we would be almost producing our own version of the 'behave' framework. This is probably unnecessary, time-consuming and it makes it unclear which rule is tested in the python implementation. For example, a 'step database' (which steps are testing which rules) will be more difficult, since the amount of steps will be lower. 
However, on the other hand, when the solution is leaning too much towards using brackets/extra symbols. Well, I think it is is safe to assume nobody enjoys reading and working with sentences like '<An>[entity] is ''nested |by|"[another_entity] if "condition" |is/is not| present. 
We discussed earlier that only a small fraction of the people reading the behave statements will read the actual python implementation. In that light, I think the compromise should be a leaning a little bit more towards readability. 

In the PR a small experiment is conducted with the statements of the 'Alignment rules' in which double quotes are used for either IFC entity types or versions (but may be updated in the future). For example:
`An "IfcAlignment" must be nested by at most 1 instance of "IfcAlignmentHorizontal"`
Perhaps a small modification, but it allows us to custom parse the middle part. Which is convienient, as a lot of rules that we created so far have a similar pattern (for example, they almost all use the same structure for producing error messaging): 
**Entity -> Relationship to -> Other entity -> (Optional:) condition**
```
       Each IfcAlignment must be nested by exactly 1 instance(s) of IfcAlignmentHorizontal # ALB002
       Each IfcAlignment must be nested by at most 1 instance(s) of IfcAlignmentVertical #ALB002
       Each IfcAlignmentHorizontal is nested by a list of only instance(s) of IfcAlignmentSegment #ALB002
       Each IfcAlignment must be directly contained in IfcSite #ALB001
       Each IfcAlignment may be nested by only the following entities: IfcAlignmentHorizontal, IfcAlignmentVertical, IfcAlignmentCant, IfcReferent #ALB003
       The IfcBuilding must be assigned to the IfcSite if IfcSite is present
```

In the current PR, a couple of those statements are modified, for example
```
Each IfcAlignment must be nested by exactly 1 instance(s) of IfcAlignmentHorizontal 
Each "IfcAlignment" must be nested by exactly 1 instance(s) of "IfcAlignmentHorizontal"
Each "IfcAlignment" may be nested by only the following entities: "IfcAlignmentHorizontal", "IfcAlignmentVertical", "IfcAlignmentCant", "IfcReferent"
```
No approach is perfect, this probably has the downside that the gherkin implementation of this step can become cluttered Additionally, we will have to differentiate between some rules in the gherkin implementation (since the parsing is mostly custom now for that part) The current PR will still need some finetuning in that part, but I think it is robust enough for a first proposal. 
On the other hand, it allows us to reuse more code than before. For example, no need to repeat steps, initiate functions, create empty error lists, etc for every new rule we add. The gherkin implementation as a whole will be less cluttered in that sense as new rules with the same pattern can be hooked into the same step implementation (and perhaps be easier to create for that sense). 

