### PR TITLE
[V - Non-Rule] Rule-specific testing

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -11,7 +11,15 @@ except ImportError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
     from main import run
 
+
 test_files = glob.glob(os.path.join(os.path.dirname(__file__), "files/**/*.ifc"), recursive=True)
+
+# test only for specific rule(s)
+DEVELOPMENT = os.environ.get('environment', 'production').lower() == 'development'
+if DEVELOPMENT:
+    test_rules = ['alb001', 'alb002'] # can also be modified to, for example, 'alb' if all the rules of a category should be tested
+    test_files = [test_file for test_file in test_files if any(x in test_file.lower() for x in test_rules)]
+
 @pytest.mark.parametrize("filename", test_files)
 def test_invocation(filename):
     results = list(run(filename))

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import sys
+import re
 
 import pytest
 import tabulate
@@ -11,14 +12,9 @@ except ImportError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
     from main import run
 
-
-test_files = glob.glob(os.path.join(os.path.dirname(__file__), "files/**/*.ifc"), recursive=True)
-
-# test only for specific rule(s)
-DEVELOPMENT = os.environ.get('environment', 'production').lower() == 'development'
-if DEVELOPMENT:
-    test_rules = ['alb001', 'alb002'] # can also be modified to, for example, 'alb' if all the rules of a category should be tested
-    test_files = [test_file for test_file in test_files if any(x in test_file.lower() for x in test_rules)]
+test_for_rules = any(re.match(r"^[a-zA-Z]{3}\d{3}$", arg) for arg in sys.argv[1:])
+test_files = [fn for fn in glob.glob(os.path.join(os.path.dirname(__file__), 
+                "files/**/*.ifc"), recursive=True) if len(sys.argv) < 2 or any(x in fn.lower() for x in sys.argv[1:]) or not test_for_rules]
 
 @pytest.mark.parametrize("filename", test_files)
 def test_invocation(filename):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -24,8 +24,9 @@ def get_test_files():
     Also applies for multiple files -> 'python3 test_main.py <path1>.ifc <path2>.ifc'
     Codes and rules can also be combined -> 'python3 test_main.py alb001 <path>.ifc'
     """
+    args = [a for a in sys.argv[1:] if not a.startswith('-')]
     rule_code_pattern = re.compile(r"^[a-zA-Z]{3}\d{3}$")
-    rule_codes = list(filter(lambda arg: rule_code_pattern.match(arg), [a for a in sys.argv[1:] if not a.startswith('-')]))
+    rule_codes = list(filter(lambda arg: rule_code_pattern.match(arg), args))
 
     test_files = []
     for code in rule_codes:
@@ -35,9 +36,9 @@ def get_test_files():
         test_files.extend(paths)
 
     file_pattern =  r".*\.ifc(\')?$" #matches ".ifc" and "ifc'"
-    test_files.extend([s.strip("'") for s in sys.argv if re.match(file_pattern, s)])
+    test_files.extend([s.strip("'") for s in args if re.match(file_pattern, s)])
 
-    if not test_files: # for example, with 'pytest -sv'
+    if not args: # for example, with 'pytest -sv'
         test_files = glob.glob(os.path.join(os.path.dirname(__file__), "files/**/*.ifc"), recursive=True)
     return test_files
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -25,7 +25,7 @@ def get_test_files():
     Codes and rules can also be combined -> 'python3 test_main.py alb001 <path>.ifc'
     """
     rule_code_pattern = re.compile(r"^[a-zA-Z]{3}\d{3}$")
-    rule_codes = list(filter(lambda arg: rule_code_pattern.match(arg), sys.argv[1:]))
+    rule_codes = list(filter(lambda arg: rule_code_pattern.match(arg), [a for a in sys.argv[1:] if not a.startswith('-')]))
 
     test_files = []
     for code in rule_codes:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -12,9 +12,15 @@ except ImportError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
     from main import run
 
-test_for_rules = any(re.match(r"^[a-zA-Z]{3}\d{3}$", arg) for arg in sys.argv[1:])
-test_files = [fn for fn in glob.glob(os.path.join(os.path.dirname(__file__), 
-                "files/**/*.ifc"), recursive=True) if len(sys.argv) < 2 or any(x in fn.lower() for x in sys.argv[1:]) or not test_for_rules]
+rule_code_pattern = re.compile(r"^[a-zA-Z]{3}\d{3}$")
+rule_codes = list(filter(lambda arg: rule_code_pattern.match(arg), sys.argv[1:]))
+
+test_files = []
+for code in rule_codes:
+    paths = glob.glob(os.path.join(os.path.dirname(__file__), "files/", code.lower(), "*.ifc"))
+    if not paths:
+        print(f"No IFC files were found for the following rule code: {code}. Please provide test files or verify the input.")
+    test_files.extend(paths)
 
 @pytest.mark.parametrize("filename", test_files)
 def test_invocation(filename):


### PR DESCRIPTION
There are many files at the moment (78 in a newly developed branch) and there is no good integration (as far as I know) between behave in the command line and gherkin. 
This functionality allows to test for specific rules (e.g. 'alb001, 'alb002') as well as categories (e.g. 'alb') just by running 'pytest -sv'