### PR TITLE
add 'Segment' and 'SectionedSurface' to list of allowed representation types

### DIFF
--- a/features/resources/valid_RepresentationIdentifier.csv
+++ b/features/resources/valid_RepresentationIdentifier.csv
@@ -10,4 +10,3 @@ Body,3D Body representation, e.g. as wireframe, surface, or solid model, of an e
 Body-Fallback,3D Body representation, e.g. as tessellation, or other surface, or boundary representation, added in addition to the solid model (potentially involving Boolean operations) of an element
 Clearance,3D clearance volume of the element. Such clearance region indicates space that should not intersect with the 'Body' representation of other elements, though may intersect with the 'Clearance' representation of other elements.
 Lighting,Representation of emitting light as a light source within a shape representation
-Segment, Partial Geometry of curves that must not be rendered seperately from the main curve

--- a/features/resources/valid_RepresentationIdentifier.csv
+++ b/features/resources/valid_RepresentationIdentifier.csv
@@ -10,3 +10,4 @@ Body,3D Body representation, e.g. as wireframe, surface, or solid model, of an e
 Body-Fallback,3D Body representation, e.g. as tessellation, or other surface, or boundary representation, added in addition to the solid model (potentially involving Boolean operations) of an element
 Clearance,3D clearance volume of the element. Such clearance region indicates space that should not intersect with the 'Body' representation of other elements, though may intersect with the 'Clearance' representation of other elements.
 Lighting,Representation of emitting light as a light source within a shape representation
+Segment, Partial Geometry of curves that must not be rendered seperately from the main curve

--- a/features/resources/valid_RepresentationType.csv
+++ b/features/resources/valid_RepresentationType.csv
@@ -6,6 +6,7 @@ Curve3D,3 dimensional curve(s)
 Surface,2 or 3 dimensional surface(s)
 Surface2D, 2 dimensional surface(s) (a region on ground view)
 Surface3D,3 dimensional surface(s)
+SectionedSurface, swept surface(s) created by sweeping open profiles along a directrix
 FillArea,2D region(s) represented as a filled area (hatching)
 Text,text defined as text literals
 AdvancedSurface,3 dimensional b-spline surface(s)
@@ -14,6 +15,7 @@ GeometricCurveSet,points, curves (2 or 3 dimensional)
 Annotation2D,points, curves (2 or 3 dimensional), hatches and text (2 dimensional)
 SurfaceModel,face based and shell based surface model(s), or tessellated surface model(s)
 Tessellation,tessellated surface representation(s) only
+Segment, partial geometry of curves that shall not be rendered sparately from the main curve
 SolidModel,including swept solid, Boolean results and Brep bodies; more specific types are:
 SweptSolid,swept area solids, by extrusion and revolution, excluding tapered sweeps
 AdvancedSweptSolid,swept area solids created by sweeping a profile along a directrix, and tapered sweeps


### PR DESCRIPTION
https://github.com/buildingSMART/ifc-gherkin-rules/issues/54

Includes the addition of 'Segment' and 'SectionedSurface' to the list of allowable representation types. 

The issue stemmed from the use of outdated documentation.

PR an be used for quick hotfix

-> 
https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC1/HTML/schema/ifcrepresentationresource/lexical/ifcshaperepresentation.htm

The documentation that is currently used as reference in this PR is 
-> 
https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcShapeRepresentation.htm

Additionally, I double-checked to ensure that there were no further missing values.