### PR TITLE
[V - Updated] Small fixes

### DIFF
--- a/features/steps/errors.py
+++ b/features/steps/errors.py
@@ -64,11 +64,11 @@ class IdenticalValuesError:
 
 @dataclass
 class InstanceCountError:
-    insts: ifcopenshell.entity_instance
+    insts: typing.Sequence[ifcopenshell.entity_instance]
     type_name: str
 
     def __str__(self):
-        if len(self.insts):
+        if self.insts:
             return f"The following {len(self.insts)} instances of type {self.type_name} were encountered: {';'.join(map(misc.fmt, self.insts))}"
         else:
             return f"No instances of type {self.type_name} were encountered"
@@ -93,25 +93,24 @@ class InstancePlacementError:
 
 @dataclass
 class InstanceStructureError:
-    # @todo reverse order to relating -> nest-relationship -> related
-    related: ifcopenshell.entity_instance
     relating: Union[Sequence, ifcopenshell.entity_instance]
+    related: typing.Sequence[ifcopenshell.entity_instance]
     relationship_type: str
-    optional_values: dict = field(default_factory=dict)
+    optional_values: typing.Dict = field(default_factory=dict)
 
     def __str__(self):
         pos_neg = 'is not' if self.optional_values.get('condition', '') == 'must' else 'is'
         directness = self.optional_values.get('directness', '')
 
-        if len(self.relating):
-            return f"The instance {misc.fmt(self.related)} {pos_neg} {directness} {self.relationship_type} (in) the following ({len(self.relating)}) instances: {';'.join(map(misc.fmt, self.relating))}"
+        if self.related:
+            return f"The instance {misc.fmt(self.relating)} {pos_neg} {directness} {self.relationship_type} (in) the following ({len(self.related)}) instances: {';'.join(map(misc.fmt, self.related))}"
         else:
-            return f"This instance {self.related} is not {self.relationship_type} anything"
+            return f"This instance {self.relating} is not {self.relationship_type} anything"
 
 
 @dataclass
 class InvalidValueError:
-    related: ifcopenshell.entity_instance
+    related: Union[str, ifcopenshell.entity_instance]
     attribute: str
     value: str
 
@@ -121,8 +120,8 @@ class InvalidValueError:
 
 @dataclass
 class PolyobjectDuplicatePointsError:
-    inst: ifcopenshell.entity_instance
-    duplicates: set
+    inst: Union[str, ifcopenshell.entity_instance]
+    duplicates: typing.Set[ifcopenshell.entity_instance]
 
     def __str__(self):
         points_desc = ''
@@ -135,7 +134,7 @@ class PolyobjectDuplicatePointsError:
 @dataclass
 class PolyobjectPointReferenceError:
     inst: ifcopenshell.entity_instance
-    points: list
+    points: typing.Sequence[ifcopenshell.entity_instance]
 
     def __str__(self):
         return f"On instance {misc.fmt(self.inst)} first point {self.points[0]} is the same as last point {self.points[-1]}, but not by reference"

--- a/features/steps/thens/nesting.py
+++ b/features/steps/thens/nesting.py
@@ -62,7 +62,7 @@ def step_impl(context, entity, fragment, other_entity):
     if getattr(context, 'applicable', True):
         for inst in context.model.by_type(entity):
             related_entities = list(map(lambda x: getattr(x, extr['object_placement'], []), getattr(inst, extr['attribute'], [])))
-            if len(related_entities):
+            if related_entities:
                 if isinstance(related_entities[0], tuple):
                     related_entities = list(related_entities[0])  # if entity has only one IfcRelNests, convert to list
                 false_elements = list(filter(lambda x: not x.is_a(other_entity), related_entities))
@@ -72,10 +72,10 @@ def step_impl(context, entity, fragment, other_entity):
                     errors.append(err.InstanceStructureError(inst, correct_elements, f'{error_log_txt}'))
                 if condition == 'a list of only':
                     if len(getattr(inst, extr['attribute'], [])) > 1:
-                        errors.append(err.InstanceStructureError(f'{error_log_txt} more than 1 list, including'))
-                    elif len(false_elements):
+                        errors.append(err.InstanceStructureError(inst, correct_elements, f'{error_log_txt} more than 1 list, including'))
+                    elif false_elements:
                         errors.append(err.InstanceStructureError(inst, false_elements, f'{error_log_txt} a list that includes'))
-                if condition == 'only' and len(false_elements):
+                if condition == 'only' and false_elements:
                     errors.append(err.InstanceStructureError(inst, correct_elements, f'{error_log_txt}'))
 
     misc.handle_errors(context, errors)


### PR DESCRIPTION
Continuation of https://github.com/buildingSMART/ifc-gherkin-rules/pull/42

The following is added:

-`if len(set()): do X ` is changed to `if set(): do X`. In these cases, point of interest is existence and not length
- Type annotations for better documentation.
- In ALB002: Reverse related & relating. They are now in the wrong order in the steps.py file (I think due to the confusion of Nest/IsNestedBy).