### PR TITLE
Add @implementer-agreement

### DIFF
--- a/features/ALB001_Alignment-in-spatial-structure.feature
+++ b/features/ALB001_Alignment-in-spatial-structure.feature
@@ -1,4 +1,5 @@
 @disabled
+@implementer-agreement
 @ALB
 Feature: ALB001 - Alignment in spatial structure
 The rule verifies, that each IfcAlignment is contained in an IfcSite.


### PR DESCRIPTION
Disabled alb rule should be tagged @implementer-agreement so that it doesn't show up twice in the report.