### PR TITLE
change scope emitted_one_passing

### DIFF
--- a/features/steps/thens/reference.py
+++ b/features/steps/thens/reference.py
@@ -8,9 +8,8 @@ from utils import geometry, misc
 def step_impl(context, something, num):
     assert something in ("edge", "oriented edge")
     
-    emitted_one_passing = False
-
     def _():
+        emitted_one_passing = False
         for inst in context.instances:
             edge_usage = geometry.get_edges(
                 context.model, inst, Counter, oriented=something == "oriented edge"


### PR DESCRIPTION
Latest commit https://github.com/buildingSMART/ifc-gherkin-rules/commit/2ccae8f4d1f3e263888d11fad7e86ba99c0f1b00 was failing the test due to a function not having access to a variable that is defined outside its scope. Defining it inside the scope fixes it. 

A bit silly one line PR, but I cannot push it directly.