### PR TITLE
fix testing disabled rules with pytest

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -44,22 +44,24 @@ def get_test_files():
 
 @pytest.mark.parametrize("filename", get_test_files())
 def test_invocation(filename):
-    results = list(run(filename))
+    gherkin_results = list(run(filename))
     base = os.path.basename(filename)
     # if base.startswith("pass-"):
-    results = [result for result in results if result[4] != 'Rule disabled']
-    results = [result for result in results if 'Rule passed' not in result[4]]
+    results = [result for result in gherkin_results if result[4] != 'Rule disabled']
+    results = [result for result in results if 'Rule passed' not in results[4]]
     print()
     print(base)
     print()
     print(f"{len(results)} errors")
-    if results:
+
+    if gherkin_results:
         print(tabulate.tabulate(
-            [[c or '' for c in r] for r in results],
-            maxcolwidths=[30] * len(results[0]),
+            [[c or '' for c in r] for r in gherkin_results],
+            maxcolwidths=[30] * len(gherkin_results[0]),
             tablefmt="simple_grid"
         ))
-    if base.startswith("fail-"):
+
+    if base.startswith("fail-") and not any(description == 'Rule disabled' for description in [result[4] for result in gherkin_results]):
         assert len(results) > 0
     elif base.startswith("pass-"):
         assert len(results) == 0

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -48,7 +48,7 @@ def test_invocation(filename):
     base = os.path.basename(filename)
     # if base.startswith("pass-"):
     results = [result for result in gherkin_results if result[4] != 'Rule disabled']
-    results = [result for result in results if 'Rule passed' not in results[4]]
+    results = [result for result in results if 'Rule passed' not in result[4]]
     print()
     print(base)
     print()


### PR DESCRIPTION
Failed error https://github.com/buildingSMART/ifc-gherkin-rules/commit/eedb41d84b549daeafb8d28379f0fd1aba409d7a

Is due to 
```
    if base.startswith("fail-"):
        assert len(results) > 0
```
In combination with 
   ` results = [result for result in results if result[4] != 'Rule disabled']`

https://github.com/buildingSMART/ifc-gherkin-rules/blob/eedb41d84b549daeafb8d28379f0fd1aba409d7a/test/test_main.py#L62C1-L63C32

The rules with 'Rule Disabled' as message gets filtered out. This way, even with files that start with 'fail' :` len(results) == 0`, 

A solution is to not overwrite the original results  from` main.run()` and check whether the rule is available before the assertion : 
`    if base.startswith("fail-") and not any(description == 'Rule disabled' for description in [result[4] for result in gherkin_results]):`

This way in combination with using the original results in tabulate, we still get a meaningful error message with testing without triggering `assert`

![example](https://github.com/buildingSMART/ifc-gherkin-rules/assets/54070862/3cba776a-4bd4-4d80-8875-8bd648f04de2)
