### PR TITLE
add decorator for error handling

### DIFF
--- a/features/steps/errors.py
+++ b/features/steps/errors.py
@@ -4,12 +4,23 @@ import typing
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Union
-from utils import geometry, ifc, misc, system
+from utils import misc
+import json
 
 @dataclass
 class RuleState:
     rule_passed: bool
 
+def handle_errors(fn):
+    def inner(*args, **kwargs):
+        generate_error_message(*args, list(fn(*args, **kwargs))) # context is always *args[0]
+    return inner
+
+def generate_error_message(context, errors):
+    error_formatter = (lambda dc: json.dumps(misc.asdict(dc), default=tuple)) if context.config.format == ["json"] else str
+    assert not errors, "Errors occured:\n{}".format(
+        "\n".join(map(error_formatter, errors))
+    )
 
 # @todo why do we have RuleSuccessInst and -Insts with identical formatting
 

--- a/features/steps/thens/existance.py
+++ b/features/steps/thens/existance.py
@@ -5,29 +5,26 @@ from behave import *
 from utils import misc
 
 @then("There must be one {representation_id} shape representation")
+@err.handle_errors
 def step_impl(context, representation_id):
-    errors = []
     if context.instances:
         for inst in context.instances:
             if inst.Representation:
                 present = representation_id in map(operator.attrgetter('RepresentationIdentifier'), inst.Representation.Representations)
                 if not present:
-                    errors.append(err.RepresentationShapeError(False, inst, representation_id))
+                    yield(err.RepresentationShapeError(False, inst, representation_id))
                 elif context.error_on_passed_rule:
-                    errors.append(err.RuleSuccessInst(True, inst))
-    misc.handle_errors(context, errors)
+                    yield(err.RuleSuccessInst(True, inst))
 
 
 @then('There must be {constraint} {num:d} instance(s) of {entity}')
+@err.handle_errors
 def step_impl(context, constraint, num, entity):
     op = misc.stmt_to_op(constraint)
-
-    errors = []
 
     if getattr(context, 'applicable', True):
         insts = context.model.by_type(entity)
         if not op(len(insts), num):
-            errors.append(err.InstanceCountError(False, insts, entity))
+            yield(err.InstanceCountError(False, insts, entity))
         elif context.error_on_passed_rule:
-            errors.append(err.RuleSuccessInsts(True, insts))
-    misc.handle_errors(context, errors)
+            yield(err.RuleSuccessInsts(True, insts))

--- a/features/steps/thens/geometry.py
+++ b/features/steps/thens/geometry.py
@@ -5,12 +5,13 @@ import math
 from behave import *
 from utils import geometry, ifc, misc
 
+
 @then("It must have no duplicate points {clause} first and last point")
+@err.handle_errors
 def step_impl(context, clause):
     assert clause in ('including', 'excluding')
     emitted_one_passing = False
     if getattr(context, 'applicable', True):
-        errors = []
         for instance in context.instances:
             entity_contexts = ifc.recurrently_get_entity_attr(context, instance, 'IfcRepresentation', 'ContextOfItems')
             precision = ifc.get_precision_from_contexts(entity_contexts)
@@ -26,10 +27,9 @@ def step_impl(context, clause):
                             break
                 comparison_nr += 1
             if duplicates:
-                errors.append(err.PolyobjectDuplicatePointsError(False, instance, duplicates))
+                yield(err.PolyobjectDuplicatePointsError(False, instance, duplicates))
             elif context.error_on_passed_rule and not emitted_one_passing:
-                errors.append(err.RuleSuccessInst(True, instance))
+                yield(err.RuleSuccessInst(True, instance))
                 emitted_one_passing = True
-        misc.handle_errors(context, errors)
 
 

--- a/features/steps/thens/nesting.py
+++ b/features/steps/thens/nesting.py
@@ -8,43 +8,40 @@ from utils import ifc, misc
 
 
 @then('Each {entity} must be nested by {constraint} {num:d} instance(s) of {other_entity}')
+@err.handle_errors
 def step_impl(context, entity, num, constraint, other_entity):
     stmt_to_op = {'exactly': operator.eq, "at most": operator.le}
     assert constraint in stmt_to_op
     op = stmt_to_op[constraint]
 
-    errors = []
-
     if getattr(context, 'applicable', True):
         for inst in context.model.by_type(entity):
             nested_entities = [entity for rel in inst.IsNestedBy for entity in rel.RelatedObjects]
             if not op(len([1 for i in nested_entities if i.is_a(other_entity)]), num):
-                errors.append(err.InstanceStructureError(False, inst, [i for i in nested_entities if i.is_a(other_entity)], 'nested by'))
+                yield(err.InstanceStructureError(False, inst, [i for i in nested_entities if i.is_a(other_entity)], 'nested by'))
             elif context.error_on_passed_rule:
-                errors.append(err.RuleSuccessInst(True, inst))
-
-    misc.handle_errors(context, errors)
+                yield(err.RuleSuccessInst(True, inst))
 
 
 @then('Each {entity} may be nested by only the following entities: {other_entities}')
+@err.handle_errors
 def step_impl(context, entity, other_entities):
     allowed_entity_types = set(map(str.strip, other_entities.split(',')))
 
-    errors = []
     if getattr(context, 'applicable', True):
         for inst in context.model.by_type(entity):
             nested_entities = [i for rel in inst.IsNestedBy for i in rel.RelatedObjects]
             nested_entity_types = set(i.is_a() for i in nested_entities)
             if not nested_entity_types <= allowed_entity_types:
                 differences = list(nested_entity_types - allowed_entity_types)
-                errors.append(err.InstanceStructureError(False, inst, [i for i in nested_entities if i.is_a() in differences], 'nested by'))
+                yield(err.InstanceStructureError(False, inst, [i for i in nested_entities if i.is_a() in differences], 'nested by'))
             elif context.error_on_passed_rule:
-                errors.append(err.RuleSuccessInst(True, inst))
+                yield(err.RuleSuccessInst(True, inst))
 
-    misc.handle_errors(context, errors)
 
 
 @then('Each {entity} {fragment} instance(s) of {other_entity}')
+@err.handle_errors
 def step_impl(context, entity, fragment, other_entity):
     reltype_to_extr = {'must nest': {'attribute': 'Nests', 'object_placement': 'RelatingObject', 'error_log_txt': 'nesting'},
                        'is nested by': {'attribute': 'IsNestedBy', 'object_placement': 'RelatedObjects', 'error_log_txt': 'nested by'}}
@@ -74,14 +71,13 @@ def step_impl(context, entity, fragment, other_entity):
                 correct_elements = list(filter(lambda x: x.is_a(other_entity), related_entities))
 
                 if condition == 'only 1' and len(correct_elements) > 1:
-                    errors.append(err.InstanceStructureError(False, inst, correct_elements, f'{error_log_txt}'))
+                    yield(err.InstanceStructureError(False, inst, correct_elements, f'{error_log_txt}'))
                 if condition == 'a list of only':
                     if len(getattr(inst, extr['attribute'], [])) > 1:
-                        errors.append(err.InstanceStructureError(False, f'{error_log_txt} more than 1 list, including'))
+                        yield(err.InstanceStructureError(False, f'{error_log_txt} more than 1 list, including'))
                     elif len(false_elements):
-                        errors.append(err.InstanceStructureError(False, inst, false_elements, f'{error_log_txt} a list that includes'))
+                        yield(err.InstanceStructureError(False, inst, false_elements, f'{error_log_txt} a list that includes'))
                 if condition == 'only' and len(false_elements):
-                    errors.append(err.InstanceStructureError(False, inst, correct_elements, f'{error_log_txt}'))
+                    yield(err.InstanceStructureError(False, inst, correct_elements, f'{error_log_txt}'))
             if len(errors) == amount_of_errors and context.error_on_passed_rule:
-                errors.append(err.RuleSuccessInst(True, inst))
-    misc.handle_errors(context, errors)
+                yield(err.RuleSuccessInst(True, inst))

--- a/features/steps/thens/reference.py
+++ b/features/steps/thens/reference.py
@@ -5,39 +5,35 @@ from collections import Counter
 from utils import geometry, misc
 
 @then("Every {something} must be referenced exactly {num:d} times by the loops of the face")
+@err.handle_errors
 def step_impl(context, something, num):
     assert something in ("edge", "oriented edge")
     emitted_one_passing = False
 
-    def _():
-        nonlocal emitted_one_passing
-        for inst in context.instances:
-            edge_usage = geometry.get_edges(
+    for inst in context.instances:
+        edge_usage = geometry.get_edges(
                 context.model, inst, Counter, oriented=something == "oriented edge"
             )
-            invalid = {ed for ed, cnt in edge_usage.items() if cnt != num}
-            valid = {ed for ed, cnt in edge_usage.items() if cnt == num}
-            for ed in invalid:
-                yield err.EdgeUseError(False, inst, ed, edge_usage[ed])
-            for ed in valid:
-                if context.error_on_passed_rule and not emitted_one_passing:
-                    yield err.RuleSuccessInst(True, inst)
-                    emitted_one_passing = True
-
-    misc.handle_errors(context, list(_()))
+        invalid = {ed for ed, cnt in edge_usage.items() if cnt != num}
+        valid = {ed for ed, cnt in edge_usage.items() if cnt == num}
+        for ed in invalid:
+            yield err.EdgeUseError(False, inst, ed, edge_usage[ed])
+        for ed in valid:
+            if context.error_on_passed_rule and not emitted_one_passing:
+                yield err.RuleSuccessInst(True, inst)
+                emitted_one_passing = True
 
 @then("Its first and last point must be identical by reference")
+@err.handle_errors
 def step_impl(context):
     emitted_one_passing = False
     
     if getattr(context, 'applicable', True):
-        errors = []
         for instance in context.instances:
             points = geometry.get_points(instance, return_type='points')
             if points[0] != points[-1]:
-                errors.append(err.PolyobjectPointReferenceError(False, instance, points))
+                yield(err.PolyobjectPointReferenceError(False, instance, points))
             elif context.error_on_passed_rule and not emitted_one_passing:
-                errors.append(err.RuleSuccessInst(True, instance))
+                yield(err.RuleSuccessInst(True, instance))
                 emitted_one_passing = True
 
-        misc.handle_errors(context, errors)

--- a/features/steps/thens/relations.py
+++ b/features/steps/thens/relations.py
@@ -7,6 +7,7 @@ from parse_type import TypeBuilder
 register_type(aggregated_or_contained_or_positioned=TypeBuilder.make_enum(dict(map(lambda x: (x, x), ("aggregated", "contained", "positioned")))))
 
 @then('Each {entity} {condition} be {directness} contained in {other_entity}')
+@err.handle_errors
 def step_impl(context, entity, condition, directness, other_entity):
     stmt_to_op = ['must', 'must not']
     assert condition in stmt_to_op
@@ -41,13 +42,12 @@ def step_impl(context, entity, condition, directness, other_entity):
             directness_achieved = bool(common_directness)  # if there's a common value -> relationship achieved
             directness_expected = condition == 'must'  # check if relationship is expected
             if directness_achieved != directness_expected:
-                errors.append(err.InstanceStructureError(False, ent, [relating_spatial_element], 'contained', optional_values={'condition': condition, 'directness': directness}))
+                yield(err.InstanceStructureError(False, ent, [relating_spatial_element], 'contained', optional_values={'condition': condition, 'directness': directness}))
             elif context.error_on_passed_rule:
-                errors.append(err.RuleSuccessInsts(True, ent))
-
-    misc.handle_errors(context, errors)
-
+                yield(err.RuleSuccessInsts(True, ent))
+                
 @then('It must be {relationship} as per {table}')
+@err.handle_errors
 def step_impl(context, relationship, table):
     stmt_to_op_forward = {'aggregated': 'Decomposes'}
     stmt_to_op_reversed = {'aggregated': 'IsDecomposedBy'}
@@ -86,7 +86,7 @@ def step_impl(context, relationship, table):
                     relation = getattr(ent, stmt_to_op[relationship], True)[0]
                 except IndexError: # no relationship found for the entity
                     if is_required:
-                        errors.append(err.InstanceStructureError(False, ent, [expected_relationship_objects], 'related to', optional_values={'condition': 'must'}))
+                        yield(err.InstanceStructureError(False, ent, [expected_relationship_objects], 'related to', optional_values={'condition': 'must'}))
                     continue
                 relationship_objects = getattr(relation, relationship_tbl_header, True)
                 if not isinstance(relationship_objects, tuple):
@@ -98,19 +98,19 @@ def step_impl(context, relationship, table):
                     is_correct = any(relationship_object.is_a(expected_relationship_object) for expected_relationship_object in expected_relationship_objects)
                     if not is_correct:
                         all_correct = False
-                        errors.append(err.InstanceStructureError(False, ent, [expected_relationship_objects], 'related to', optional_values={'condition': 'must'}))
+                        yield(err.InstanceStructureError(False, ent, [expected_relationship_objects], 'related to', optional_values={'condition': 'must'}))
                         invalid.add(ent)
 
                 if all_correct:
                     checked.add(ent)
 
     for ent in checked - invalid:
-        errors.append(err.RuleSuccessInsts(True, ent))
+        yield(err.RuleSuccessInsts(True, ent))
 
-    misc.handle_errors(context, errors)
 
 
 @then('The {related} must be assigned to the {relating} if {other_entity} {condition} present')
+@err.handle_errors
 def step_impl(context, related, relating, other_entity, condition):
     # @todo reverse order to relating -> nest-relationship -> related
     pred = misc.stmt_to_op(condition)
@@ -126,15 +126,14 @@ def step_impl(context, related, relating, other_entity, condition):
             for inst in context.model.by_type(related):
                 for rel in getattr(inst, 'Decomposes', []):
                     if not rel.RelatingObject.is_a(relating):
-                        errors.append(err.InstanceStructureError(False, inst, [rel.RelatingObject], 'assigned to'))
+                        yield(err.InstanceStructureError(False, inst, [rel.RelatingObject], 'assigned to'))
                     elif context.error_on_passed_rule:
-                        errors.append(err.RuleSuccessInst(True, inst))
-
-    misc.handle_errors(context, errors)
+                        yield(err.RuleSuccessInst(True, inst))
 
 
 
 @then('Each {entity} {decision} be {relationship:aggregated_or_contained_or_positioned} {preposition} {other_entity} {condition}')
+@err.handle_errors
 def step_impl(context, entity, decision, relationship, preposition, other_entity, condition):
     acceptable_decisions = ['must', 'must not']
     assert decision in acceptable_decisions
@@ -175,7 +174,7 @@ def step_impl(context, entity, decision, relationship, preposition, other_entity
                     if check_directness:
                         observed_directness.update({'directly'})
                     if decision == 'must not':
-                        errors.append(err.RelationshipError(False, ent, decision, condition, relationship, preposition, other_entity))
+                        yield(err.RelationshipError(False, ent, decision, condition, relationship, preposition, other_entity))
                         break
                 if hasattr(relating_element, other_entity_reference): # in case the relation points to a wrong instance
                     while len(getattr(relating_element, other_entity_reference)) > 0:
@@ -187,7 +186,7 @@ def step_impl(context, entity, decision, relationship, preposition, other_entity
                                 observed_directness.update({'indirectly'})
                                 break
                             if decision == 'must not':
-                                errors.append(err.RelationshipError(False, ent, decision, condition, relationship, preposition, other_entity))
+                                yield(err.RelationshipError(False, ent, decision, condition, relationship, preposition, other_entity))
                                 break
 
             if check_directness:
@@ -195,20 +194,18 @@ def step_impl(context, entity, decision, relationship, preposition, other_entity
                 directness_achieved = bool(common_directness)  # if there's a common value -> relationship achieved
                 directness_expected = decision == 'must'  # check if relationship is expected
                 if directness_achieved != directness_expected:
-                    errors.append(err.RelationshipError(False, ent, decision, condition, relationship, preposition, other_entity))
+                    yield(err.RelationshipError(False, ent, decision, condition, relationship, preposition, other_entity))
                 elif context.error_on_passed_rule:
-                    errors.append(err.RuleSuccessInsts(True, ent))
+                    yield(err.RuleSuccessInsts(True, ent))
             if context.error_on_passed_rule and decision == 'must not' and not relationship_reached:
-                errors.append(err.RuleSuccessInsts(True, ent))
-    misc.handle_errors(context, errors)
+                yield(err.RuleSuccessInsts(True, ent))
 
 @then('Each {entity} must not be referenced by itself directly or indirectly')
+@err.handle_errors
 def step_impl(context, entity):
     relationship = {'IfcGroup': ('HasAssignments', 'IfcRelAssignsToGroup', 'RelatingGroup')}
     inv, ent, attr = relationship[entity]
     
-    errors = []
-
     def get_memberships(inst):
         for rel in filter(misc.is_a(ent), getattr(inst, inv, [])):
             container = getattr(rel, attr)
@@ -218,8 +215,6 @@ def step_impl(context, entity):
     if getattr(context, 'applicable', True):
         for inst in context.model.by_type(entity):
             if inst in get_memberships(inst):
-                errors.append(err.CyclicGroupError(False, inst))
+                yield(err.CyclicGroupError(False, inst))
             elif context.error_on_passed_rule:
-                errors.append(err.RuleSuccessInsts(True, inst))
-    
-    misc.handle_errors(context, errors)
+                yield(err.RuleSuccessInsts(True, inst))

--- a/features/steps/utils/misc.py
+++ b/features/steps/utils/misc.py
@@ -56,14 +56,6 @@ def fmt(x):
             return "...".join((v[:25], v[-7:]))
         return v
 
-
-def handle_errors(context, errors):
-    error_formatter = (lambda dc: json.dumps(asdict(dc), default=tuple)) if context.config.format == ["json"] else str
-    assert not errors, "Errors occured:\n{}".format(
-        "\n".join(map(error_formatter, errors))
-    )
-
-
 def include_subtypes(stmt):
     # todo replace by pyparsing?
     stmt = strip_split(stmt, strp='[]', splt=' ')


### PR DESCRIPTION
Decoupling of added functionality https://github.com/buildingSMART/ifc-gherkin-rules/pull/72

See conversation in https://github.com/buildingSMART/ifc-gherkin-rules/pull/71

>     It would also be interesting to wrap the then step error handling in a decorator, so that the need for manually calling misc.handle_errors() is eliminated. Conceptually:

This way, we get rid of manually adding 
`errors = []`
and handling of errors with 
`misc.handle_errors(context, errors)`