### PR TITLE
restructure behave validation outcome

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -66,25 +66,34 @@ def get_test_files():
 def test_invocation(filename):
     gherkin_results = list(run(filename))
     base = os.path.basename(filename)
-    # if base.startswith("pass-"):
-    results = [result for result in gherkin_results if result[4] != 'Rule disabled']
-    results = [result for result in results if 'Rule passed' not in result[4]]
+
+    filtered_results = [result for result in gherkin_results if result.severity != 'passed' and not result.disabled]
     print()
     print(base)
     print()
-    print(f"{len(results)} errors")
+    print(f"{len(filtered_results)} errors")
 
-    if gherkin_results:
+    if filtered_results:
+        table_data = [
+        [
+            f"{result.feature.name}/{result.scenario.name}.v{result.feature.version}" if result.severity == 'failed' and result.scenario else f"{result.feature.name}.v{result.feature.version}",
+            result.feature.github_source_location,
+            result.scenario.latest_step if result.scenario else '',
+            result.inst if result.inst is not None else '',
+            result.message
+        ]
+        for result in gherkin_results]
         print(tabulate.tabulate(
-            [[c or '' for c in r] for r in gherkin_results],
-            maxcolwidths=[30] * len(gherkin_results[0]),
+            table_data,
+            maxcolwidths=[30] * len(table_data),
             tablefmt="simple_grid"
         ))
 
-    if base.startswith("fail-") and not any(description == 'Rule disabled' for description in [result[4] for result in gherkin_results]):
-        assert len(results) > 0
+    if base.startswith("fail-") and not any(result.disabled for result in gherkin_results):
+        assert len(filtered_results) > 0
     elif base.startswith("pass-"):
-        assert len(results) == 0
+        assert len(filtered_results) == 0
+
 
 if __name__ == "__main__":
     pytest.main(["-s", __file__])

--- a/validation_outcome.py
+++ b/validation_outcome.py
@@ -1,0 +1,81 @@
+import ifcopenshell
+from typing import Optional, Union, Tuple, Any, List, Literal
+
+from pydantic import ConfigDict, model_validator
+
+from pydantic import BaseModel, ConfigDict
+
+class ConfiguredBaseModel(BaseModel):
+    """Base Pydantic model with assignment validation enabled.
+
+    Serves as a base class for Pydantic models, enabling validation when instance values are changed.
+    """
+    model_config = ConfigDict(validate_assignment=True)
+
+class Scenario(ConfiguredBaseModel):
+    name : str = ""
+    steps: List[Any] = []
+    latest_step: str = ""
+    feature: Optional['Feature'] = None
+    validation_results : List['ValidationOutcome'] = []
+
+    @model_validator(mode='before')
+    def add_to_feature(cls, values):
+        """
+        Ensure bilaterial relationship between feature and scenario
+        """
+        feature = values.get('feature')
+        if feature:
+            scenario = cls.model_construct(_fields_set=values.keys(), **values)
+            if scenario not in feature.scenario_list:
+                feature.scenario_list.append(scenario)
+        return values
+    
+    def __eq__(self, other):
+        """
+        Prevent duplicates in the 'scenario_list' of a Feature.
+        This ensures accurate retrieval of scenarios associated with a specific feature.
+        """
+        if not isinstance(other, Scenario):
+            return False
+        return [step['name'] for step in self.steps] == [step['name'] for step in other.steps]
+
+    def __hash__(self):
+        return hash(tuple(step['name'] for step in self.steps))
+
+
+class Feature(ConfiguredBaseModel):
+    name : str = "" # as in Feature : 'ABC001 - Test Alignment Rule'
+    description: str = "" # 'This rule verifies that alignment is correct'
+    filename : str = "" # ABC001_Test-alignment-rule
+    location : str = "" 
+    github_source_location : str = ''
+    version : int = 1
+    tags: List[str] = []
+    scenario_list : List['Scenario'] = []
+
+
+class ValidationOutcome(ConfiguredBaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    severity : Literal['failed', 'passed'] = "passed"
+    disabled : bool = False
+    message : str = ""
+    scenario : Optional[Scenario] = None
+    feature : Feature
+    ifc_filepath : str = ""
+    inst: Optional[Union[str, Tuple[Any, Any], ifcopenshell.entity_instance]] = None
+
+
+    @model_validator(mode='before')
+    def add_to_scenario(cls, values):
+        """
+        Ensure bilaterial relationship between feature and scenario
+        """
+        scenario = values.get('scenario')
+        if scenario:
+            result = cls.model_construct(_fields_set=values.keys(), **values)
+            if result not in scenario.validation_results:
+                scenario.validation_results.append(result)
+        return values
+    


### PR DESCRIPTION
Continuation of https://github.com/buildingSMART/ifc-gherkin-rules/pull/74

The idea is to encapsulate the results of Behave tests within a `Pydantic` class. This approach has two distinct pathways: when integrated with GitHub's CI/CD pipeline, the results are verified using `ValidationResult(**v)`, ensuring that the `rule-creation conventions` are met. Alternatively, for scenarios where validation is unnecessary, the results can be rapidly constructed without validation checks using `ValidationResult.model_construct(**v)`. 

Additionally, the system provides a 'query' function that allows for navigation through the test results to access associated `features` and `steps`. This functionality might particularly be advantageous for pinpointing `activation criteria`—often nested within related steps—or for compiling various types of messages, such as `warnings`, `errors`, and _success_.

A couple of examples : 

### Related scenarios
```
gherkin_results[9].scenario.name
'Agreement on attributes being nested within a decomposition relationship'
```

### Executed steps
```
[step['name'] for step in gherkin_results[9].scenario.steps]
[
'A file with Schema Identifier "IFC4X3" or "IFC4X3_TC1" or "IFC4X3_ADD1"',
'Each IfcAlignmentHorizontal must nest only 1 instance(s) of IfcAlignment',
'Each IfcAlignmentVertical must nest only 1 instance(s) of IfcAlignment',
'Each IfcAlignmentCant must nest only 1 instance(s) of IfcAlignment',
]
```

### Executed Scenarios
```
[scenario.name for scenario in gherkin_results[9].feature.scenario_list]
[
'Agreement on nested attributes of IfcAlignment'
'Agreement on attributes being nested within a decomposition relationship'
'Agreement of structure of alignments segments'
'Agreement of the segments of the horizontal alignment'
'Agreement of the segments of the vertical alignment'
'Agreement of the segments of the cant alignment'
]
```