### PR TITLE
mark_blocking_schema_rule

### DIFF
--- a/features/IFC001-only-official-ifc-versions-allowed.feature
+++ b/features/IFC001-only-official-ifc-versions-allowed.feature
@@ -1,5 +1,4 @@
-@implementer-agreement
-@critical
+@blocking
 @IFC
 Feature: IFC101 - Only Official IFC versions allowed
 

--- a/main.py
+++ b/main.py
@@ -12,8 +12,9 @@ from enum import Flag, auto
 class RuleType(Flag):
     INFORMAL_PROPOSITION = auto()
     IMPLEMENTER_AGREEMENT = auto()
-    ALL = INFORMAL_PROPOSITION | IMPLEMENTER_AGREEMENT
-
+    BLOCKING = auto()
+    ALL = INFORMAL_PROPOSITION | IMPLEMENTER_AGREEMENT | BLOCKING
+    
     @staticmethod
     def from_argv(argv):
         try:
@@ -49,9 +50,9 @@ def run(filename, instance_as_str=True, rule_type=RuleType.ALL, with_console_out
 
     tag_filter = []
     if rule_type != RuleType.ALL:
-        tag_filter.append(
+        tag_filter = [
             '--tags=' + ' and '.join(['@' + nm.lower().replace("_", "-") for nm, v in RuleType.__members__.items() if v in rule_type])
-        )
+        ]
     else:
         tag_filter.append('--tags=-disabled')
 


### PR DESCRIPTION
Add `BlOCKING` to enum RuleType and `@blocking `tag to rule checking IFC schema. 

Possibly a quick and effective solution to add blocking-validation-task to run before implementer-agreement and informal-proposition tasks (?)

In pipeline-validation 

add 
```
class blocking_validation_task(gherkin_validation_task):
    flag = "--blocking"
    db_class = database.blocking_task
```
to
https://github.com/buildingSMART/validate/blob/7a685d3d329f8d8904bf5ad0fe6f7928e6c10143/application/worker.py#L221

and 
```
class blocking_task(gherkin_task):
    __mapper_args__ = {
        "polymorphic_identity": "blocking_task",
    }    
```
to
https://github.com/buildingSMART/validate/blob/7a685d3d329f8d8904bf5ad0fe6f7928e6c10143/application/database.py#L202
