### PR TITLE
Outcome unification

### DIFF
--- a/features/steps/thens/existance.py
+++ b/features/steps/thens/existance.py
@@ -11,7 +11,7 @@ def step_impl(context, inst, representation_id):
         present = representation_id in map(operator.attrgetter('RepresentationIdentifier'),
                                            inst.Representation.Representations)
         if not present:
-            yield ValidationOutcome(inst=inst, expected=1, observed=None, severity=OutcomeSeverity.ERROR)
+            yield ValidationOutcome(inst=inst, severity=OutcomeSeverity.ERROR)
 
 
 @gherkin_ifc.step('There must be {constraint} {num:d} instance(s) of {entity}')
@@ -23,13 +23,12 @@ def step_impl(context, inst, constraint, num, entity):
         instances_in_model = context.model.by_type(entity)
 
         if not op(len(instances_in_model), num):
-            yield ValidationOutcome(inst=inst, expected=num, observed=len(instances_in_model), severity=OutcomeSeverity.ERROR)
+            yield ValidationOutcome(inst=inst, observed=instances_in_model, severity=OutcomeSeverity.ERROR)
 
 
 @gherkin_ifc.step('There must be {num:d} representation item(s)')
 def step_impl(context, inst, num):
     if inst is not None:
         for v in inst:
-            observed = len(v)
-            if observed != num:
-                yield ValidationOutcome(inst=inst, expected=num, observed=observed, severity=OutcomeSeverity.ERROR)
+            if len(v) != num:
+                yield ValidationOutcome(inst=inst, observed=v, severity=OutcomeSeverity.ERROR)

--- a/features/steps/thens/geometry.py
+++ b/features/steps/thens/geometry.py
@@ -13,16 +13,8 @@ def step_impl(context, inst, clause):
     entity_contexts = ifc.recurrently_get_entity_attr(context, inst, 'IfcRepresentation', 'ContextOfItems')
     precision = ifc.get_precision_from_contexts(entity_contexts)
     points_coordinates = geometry.get_points(inst)
-    comparison_nr = 1
-    duplicates = set()
-    for i in itertools.combinations(points_coordinates, 2):
-        if math.dist(i[0], i[1]) < precision:
-            if clause == 'including' or (clause == 'excluding' and comparison_nr != len(points_coordinates) - 1):
-                # combinations() produces tuples in a sorted order, first and last item is compared with items 0 and n-1
-                duplicates.add(i)
-                if len(duplicates) > 2:  # limit nr of reported duplicate points to 3 for error readability
-                    break
-        comparison_nr += 1
-    if duplicates:
-        yield ValidationOutcome(inst=inst, expected="No duplicates", observed="Duplicates", severity=OutcomeSeverity.ERROR)
-
+    for i, j in itertools.combinations(range(len(points_coordinates)), 2):
+        # combinations() produces tuples in a sorted order, first and last item is compared with items 0 and n-1
+        if clause == 'including' or (clause == 'excluding' and (i, j) == (0, len(points_coordinates) - 1)):
+            if math.dist(points_coordinates[i], points_coordinates[j]) < precision:
+                yield ValidationOutcome(inst=inst, observed=(points_coordinates[i], points_coordinates[j]), severity=OutcomeSeverity.ERROR)

--- a/features/steps/thens/nesting.py
+++ b/features/steps/thens/nesting.py
@@ -24,9 +24,10 @@ def step_impl(context, inst, num, constraint, other_entity):
     op = stmt_to_op[constraint]
 
     nested_entities = [entity for rel in inst.IsNestedBy for entity in rel.RelatedObjects]
-    amount_found = len([1 for i in nested_entities if i.is_a(other_entity)])
+    nested_of_type = [i for i in nested_entities if i.is_a(other_entity)]
+    amount_found = len(nested_of_type)
     if not op(amount_found, num):
-        yield ValidationOutcome(inst=inst, expected=num, observed=amount_found, severity=OutcomeSeverity.ERROR)
+        yield ValidationOutcome(inst=inst, observed=nested_of_type, severity=OutcomeSeverity.ERROR)
 
 
 @gherkin_ifc.step('It must be nested by only the following entities: {other_entities}')
@@ -36,10 +37,7 @@ def step_impl(context, inst, other_entities):
     nested_entities = [i for rel in inst.IsNestedBy for i in rel.RelatedObjects]
     nested_entity_types = set(i.is_a() for i in nested_entities)
     if not nested_entity_types <= allowed_entity_types:
-        yield ValidationOutcome(inst=inst, expected=str(allowed_entity_types), observed=allowed_entity_types - nested_entity_types, severity=OutcomeSeverity.ERROR)
-    else:
-        yield ValidationOutcome(inst=inst, severity=OutcomeSeverity.PASSED)
-
+        yield ValidationOutcome(inst=inst, observed=nested_entity_types, severity=OutcomeSeverity.ERROR)
 
 
 @gherkin_ifc.step('It {fragment:nested_sentences} instance(s) of {other_entity}')
@@ -68,12 +66,12 @@ def step_impl(context, inst, fragment, other_entity):
         correct_elements = list(filter(lambda x: x.is_a(other_entity), related_entities))
 
         if condition == 'only 1' and len(correct_elements) > 1:
-            yield ValidationOutcome(inst=inst, expected=1, observed=len(correct_elements), severity=OutcomeSeverity.ERROR)
+            yield ValidationOutcome(inst=inst, observed=len(correct_elements), severity=OutcomeSeverity.ERROR)
         if condition == 'a list of only':
             if len(getattr(inst, extr['attribute'], [])) > 1:
-                yield ValidationOutcome(inst=inst, expected=other_entity, observed=false_elements, severity=OutcomeSeverity.ERROR)
+                yield ValidationOutcome(inst=inst, expected=other_entity, observed=related_entities, severity=OutcomeSeverity.ERROR)
             elif len(false_elements):
-                yield ValidationOutcome(inst=inst, expected=other_entity, observed=false_elements, severity=OutcomeSeverity.ERROR)
+                yield ValidationOutcome(inst=inst, expected=other_entity, observed=related_entities, severity=OutcomeSeverity.ERROR)
         if condition == 'only' and len(false_elements):
-            yield ValidationOutcome(inst=inst, expected=correct_elements, observed=false_elements, severity=OutcomeSeverity.ERROR)
+            yield ValidationOutcome(inst=inst, expected=correct_elements, observed=related_entities, severity=OutcomeSeverity.ERROR)
 

--- a/features/steps/thens/reference.py
+++ b/features/steps/thens/reference.py
@@ -11,15 +11,12 @@ def step_impl(context, inst, something, num):
     edge_usage = geometry.get_edges(
             context.model, inst, Counter, oriented=something == "oriented edge"
         )
-    invalid = {ed for ed, cnt in edge_usage.items() if cnt != num}
-    if invalid:
-        yield ValidationOutcome(inst=inst, expected=num, observed=edge_usage[list(invalid)[0]], severity=OutcomeSeverity.ERROR)
+    for ed in {ed for ed, cnt in edge_usage.items() if cnt != num}:
+        yield ValidationOutcome(inst=inst, observed=edge_usage[ed], severity=OutcomeSeverity.ERROR)
         
-
 
 @gherkin_ifc.step("Its first and last point must be identical by reference")
 def step_impl(context, inst):
     points = geometry.get_points(inst, return_type='points')
     if points[0] != points[-1]:
-        yield ValidationOutcome(inst=inst, expected="identical", observed="not identical", severity=OutcomeSeverity.ERROR)
-
+        yield ValidationOutcome(inst=inst, observed=[points[0], points[-1]], severity=OutcomeSeverity.ERROR)


### PR DESCRIPTION
Some notes:

- I ended up using most of the `expected` columns. Because I felt they duplicated too much of the step definition. But on the other hand I don't know how obvious the failing step is to the end user. But on the other hand I don't know how expected=1 would really help understanding which step is failing in case of many steps. I think maybe we come to the conclusion that we do need the failing step in the database and maybe the simplest way is to do that generically just the full step text as we get it from behave in the decorator.
- For observed I applied two changes in direction as well: (a) in case of counts, instead of listing the count as observed I referened the list of instances (b) in case of partial results "at least two items of type X" we test the length of [i for i in values if i is X] but I referenced the full list in observed, not just those of value X, because I think that is closer to what is actually observed.
- I removed one case of explicitly yielding OutcomeSeverity.PASSED. I think that should be handled automatically now
- I no longer selectively yield outcomes (like only the first). I think with the database backend it should be efficient enough to capture all?