### PR TITLE
Check version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Setup version bump env vars
+      id: envvars
+      run: |
+        echo "TARGET_BRANCH=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+        echo "PULL_REQUEST=$PULL_REQUEST" >> $GITHUB_OUTPUT
+      env:
+        TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || 'development' }}
+        PULL_REQUEST: ${{ github.event_name == 'pull_request' && 'True' || 'False' }}
+
     - name: Test with pytest
       run: |
+        pytest -sv --target_branch=${{ steps.envvars.outputs.TARGET_BRANCH }} --pull_request=${{ steps.envvars.outputs.PULL_REQUEST }}
         pytest -sv

--- a/features/environment.py
+++ b/features/environment.py
@@ -3,7 +3,7 @@ from behave.model import Scenario
 from collections import Counter
 import os
 import random
-from rule_creation_protocol import protocol
+from rule_creation_protocol import protocol, version_check
 import copy
 
 from validation_results import ValidationOutcome, ValidationOutcomeCode, OutcomeSeverity
@@ -44,7 +44,9 @@ def before_feature(context, feature):
             'tags': context.tags, 
             'location': context.feature.location.filename, 
             'steps': [{'keyword': step.keyword, 'name': step.name} for scenario in context.feature.scenarios for step in scenario.steps],
-            'filename' : ifc_filename_incl_path # filename that comes directly from 'main.py'
+            'filename' : ifc_filename_incl_path, # filename that comes directly from 'main.py'
+            'target_branch': context.config.userdata.get('target_branch', 'development'), 
+            'pull_request': context.config.userdata.get('pull_request', False) #e.g. don't run twice with the wtih_console_output variable
             }
         protocol_errors = protocol.enforce(convention_attrs)
         for error in protocol_errors:

--- a/features/rule_creation_protocol/version_check.py
+++ b/features/rule_creation_protocol/version_check.py
@@ -1,0 +1,29 @@
+import subprocess
+import re
+from .errors import ProtocolError
+
+def get_changed_feature_files(target_branch):
+    changed_files = subprocess.getoutput(f"git diff --name-only {target_branch}").split("\n")
+    feature_files = [f for f in changed_files if f.endswith(".feature")]
+    return feature_files
+
+def check_version_bump(file):
+    # Compare the file from the current branch to the target_branch
+    diff_output = subprocess.getoutput(f"git diff {file}")
+    versions = re.findall(r"@version(\d+)", diff_output)
+    versions = [int(v) for v in versions]
+    if not versions:
+        raise ProtocolError(
+            value = None,
+            message = "When changing a feature file, the version number must be bumped"
+        )
+    return versions[1] > versions[0]  # Check version bump
+
+def enforce(target_branch = 'main'):
+    feature_files = get_changed_feature_files(target_branch)
+    for file in feature_files:
+        if not check_version_bump(file):
+            raise ProtocolError(
+                value = None,
+                message = "When changing a feature file, the version must be bumped"
+            )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,14 @@
+
+def pytest_addoption(parser):
+    """"
+    Method to allow --validate-dev to pytest : 'pytest -sv --validate-dev'
+    Can be accessed with pytest 'request.config.getoption("--validate-dev")'
+    """
+    parser.addoption(
+        "--target_branch", action="store", default='development',
+        help="target branch for pull requests"
+    )
+    parser.addoption(
+        "--pull_request", action="store", default="False",
+        help="indicates if the test run is for a pull request"
+    )

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,8 +64,12 @@ def get_test_files():
     return test_files
 
 @pytest.mark.parametrize("filename", get_test_files())
-def test_invocation(filename):
-    gherkin_results = list(run(filename, execution_mode=ExecutionMode.TESTING))
+def test_invocation(request, filename):
+    run_kwargs = {
+        "target_branch": request.config.getoption("--target_branch"),
+        "pull_request": request.config.getoption("--pull_request").lower() == 'true' # github env returns True or False represented as a stringg
+    }
+    gherkin_results = list(run(filename, execution_mode=ExecutionMode.TESTING, **run_kwargs))
     base = os.path.basename(filename)
     results = [result for result in gherkin_results if result[4] != 'Rule disabled']
     print()


### PR DESCRIPTION
In case something is modified in a .feature file, the version number needs to be bumped. This scripts checks that automatically. In github CI/CD, it only gets triggered on pull requests and not on push. This will prevent confusing situations, for instance when a .feature file is updated multiple times within a specific branch that is used for a pull request.

Specifically, the number referenced to in the @version tag. For example in https://github.com/buildingSMART/ifc-gherkin-rules/blob/874bb0843c4bbdae0180b9c9430fd47e358082e0/features/ALA002_Alignment-same-number-of-segments-in-business-logic-and-geometry.feature#L2

Related to https://github.com/buildingSMART/ifc-gherkin-rules/pull/147

As well as related to the issue https://github.com/buildingSMART/ifc-gherkin-rules/issues/97

The purpose is to setup a rule catalog. So that we can output the correct `Then` step of the validation outcome to the end-user without unnecessarily populating the database.  However, for this we'll have to ensure we don't output an outdated version of the .feature file.