### PR TITLE
 Properly clean up custom stack frames 

### DIFF
--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -228,7 +228,7 @@ def handle_given(context, fn, **kwargs):
         else:
             pass # (1) -> context.applicable is set within the function ; replace this with a simple True/False and set applicability here?
     else:
-        context._push() # for attribute stacking
+        context._push('attribute') # for attribute stacking
         if 'at depth 1' in context.step.name: 
             #todo @gh develop a more standardize approach
             context.instances = list(filter(None, map_given_state(context.instances, fn, context, depth=1, **kwargs)))


### PR DESCRIPTION
I've studied a bit better what behave does with these stack frames. They have a layername which is one of testrun/feature/scenario and these are being pushed and popped to govern the scope of variables that endusers set on the context. We already naively observed once that when we ourselves push a bunch of levels on the stack they are retained for the entire testrun. And that is because behave doesn't check the layernames when popping. It just removes one. When we add a bunch of layers, it removes one of us. And then adds a new one that gives us the new feature name. However! Previously, we then erase this new layer containing the new feature name when we revert the stack depth back to two, which is testrun+feature (but the previous feature). So my change now correctly tags are own layers distinctively and removes them in after_scenario().

That's a valuable lesson for not touching each other's privates. _push() _pop() and _stack are al marked with a leading underscore. But I think in our current use of them, we should be in line again with the intended usage.

Note about the removal of `context.gherkin_outcomes = []`. This was already done also at before_scenario() so was redundant.