### PR TITLE
Fix/val-459-combine-relationships-with-stacked-selection

### DIFF
--- a/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
+++ b/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
@@ -10,7 +10,7 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentHorizontal
     Given A relationship IfcRelNests from IfcAlignmentHorizontal to IfcAlignmentSegment and following that
-    Given Its final segment at depth 1
+    Given Its final element at depth 1 filtering by id
     Given Its attribute DesignParameters
     Then The SegmentLength of the final IfcAlignmentHorizontalSegment must be 0
 
@@ -18,7 +18,7 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentVertical
     Given A relationship IfcRelNests from IfcAlignmentVertical to IfcAlignmentSegment and following that
-    Given Its final segment at depth 1
+    Given Its final element at depth 1 filtering by id
     Given Its attribute DesignParameters
     Then The HorizontalLength of the final IfcAlignmentVerticalSegment must be 0
 
@@ -26,7 +26,6 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentCant
     Given A relationship IfcRelNests from IfcAlignmentCant to IfcAlignmentSegment and following that
-    Given Its final segment at depth 1
+    Given Its final element at depth 1 filtering by id
     Given Its attribute DesignParameters
     Then The HorizontalLength of the final IfcAlignmentCantSegment must be 0
-

--- a/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
+++ b/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
@@ -12,7 +12,7 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A relationship IfcRelNests from IfcAlignmentHorizontal to IfcAlignmentSegment and following that
     Given Its final element at depth 1
     Given Its attribute DesignParameters
-    Then The SegmentLength of the final IfcAlignmentHorizontalSegment must be 0
+    Then The SegmentLength of the IfcAlignmentHorizontalSegment must be 0
 
   Scenario: Validating final segment of vertical alignment business logic
     Given A model with Schema "IFC4.3"
@@ -20,7 +20,7 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A relationship IfcRelNests from IfcAlignmentVertical to IfcAlignmentSegment and following that
     Given Its final element at depth 1
     Given Its attribute DesignParameters
-    Then The HorizontalLength of the final IfcAlignmentVerticalSegment must be 0
+    Then The HorizontalLength of the IfcAlignmentVerticalSegment must be 0
 
   Scenario: Validating final segment of cant alignment business logic
     Given A model with Schema "IFC4.3"
@@ -28,4 +28,4 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A relationship IfcRelNests from IfcAlignmentCant to IfcAlignmentSegment and following that
     Given Its final element at depth 1
     Given Its attribute DesignParameters
-    Then The HorizontalLength of the final IfcAlignmentCantSegment must be 0
+    Then The HorizontalLength of the IfcAlignmentCantSegment must be 0

--- a/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
+++ b/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
@@ -9,23 +9,24 @@ Feature: ALB015 - Alignment business logic zero length final segment
   Scenario: Validating final segment of horizontal alignment business logic
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentHorizontal
-    Given A relationship IfcRelNests from IfcAlignmentSegment to IfcAlignmentHorizontal
-    Given Its final IfcAlignmentSegment
+    Given A relationship IfcRelNests from IfcAlignmentHorizontal to IfcAlignmentSegment and following that
+    Given Its final segment at depth 1
     Given Its attribute DesignParameters
     Then The SegmentLength of the final IfcAlignmentHorizontalSegment must be 0
 
   Scenario: Validating final segment of vertical alignment business logic
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentVertical
-    Given A relationship IfcRelNests from IfcAlignmentSegment to IfcAlignmentVertical
-    Given Its final IfcAlignmentSegment
+    Given A relationship IfcRelNests from IfcAlignmentVertical to IfcAlignmentSegment and following that
+    Given Its final segment at depth 1
     Given Its attribute DesignParameters
     Then The HorizontalLength of the final IfcAlignmentVerticalSegment must be 0
 
   Scenario: Validating final segment of cant alignment business logic
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentCant
-    Given A relationship IfcRelNests from IfcAlignmentSegment to IfcAlignmentCant
-    Given Its final IfcAlignmentSegment
+    Given A relationship IfcRelNests from IfcAlignmentCant to IfcAlignmentSegment and following that
+    Given Its final segment at depth 1
     Given Its attribute DesignParameters
     Then The HorizontalLength of the final IfcAlignmentCantSegment must be 0
+

--- a/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
+++ b/features/ALB015_Alignment-business-logic-zero-length-final-segment.feature
@@ -10,7 +10,7 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentHorizontal
     Given A relationship IfcRelNests from IfcAlignmentHorizontal to IfcAlignmentSegment and following that
-    Given Its final element at depth 1 filtering by id
+    Given Its final element at depth 1
     Given Its attribute DesignParameters
     Then The SegmentLength of the final IfcAlignmentHorizontalSegment must be 0
 
@@ -18,7 +18,7 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentVertical
     Given A relationship IfcRelNests from IfcAlignmentVertical to IfcAlignmentSegment and following that
-    Given Its final element at depth 1 filtering by id
+    Given Its final element at depth 1
     Given Its attribute DesignParameters
     Then The HorizontalLength of the final IfcAlignmentVerticalSegment must be 0
 
@@ -26,6 +26,6 @@ Feature: ALB015 - Alignment business logic zero length final segment
     Given A model with Schema "IFC4.3"
     Given An IfcAlignmentCant
     Given A relationship IfcRelNests from IfcAlignmentCant to IfcAlignmentSegment and following that
-    Given Its final element at depth 1 filtering by id
+    Given Its final element at depth 1
     Given Its attribute DesignParameters
     Then The HorizontalLength of the final IfcAlignmentCantSegment must be 0

--- a/features/ALS015_Alignment-representation-zero-length-final-segment.feature
+++ b/features/ALS015_Alignment-representation-zero-length-final-segment.feature
@@ -14,7 +14,7 @@ Background: Validating final segment of alignment geometry (representation).
   Given Its attribute Representations
   Given its attribute Items
   Given its attribute Segments
-  Given Its final segment at depth 1
+  Given Its final element at depth 1
 
 Scenario: Validating that the final alignment geometry segment is of length 0.0.
   Then The SegmentLength of the final segment must be 0

--- a/features/ALS015_Alignment-representation-zero-length-final-segment.feature
+++ b/features/ALS015_Alignment-representation-zero-length-final-segment.feature
@@ -17,7 +17,7 @@ Background: Validating final segment of alignment geometry (representation).
   Given Its final element at depth 1
 
 Scenario: Validating that the final alignment geometry segment is of length 0.0.
-  Then The SegmentLength of the final segment must be 0
+  Then The SegmentLength of the segment must be 0
 
 Scenario: Validating that the final alignment geometry segment is discontinuous.
   Given Its attribute Transition

--- a/features/OJP001_Relative-placement-for-elements-aggregated-to-another-element.feature
+++ b/features/OJP001_Relative-placement-for-elements-aggregated-to-another-element.feature
@@ -11,7 +11,7 @@ with an PlacementRelTo attribute pointing to the IfcLocalPlacement of the contai
 
       Given A model with Schema "IFC2X3" or "IFC4"
       Given An IfcElement
-      Given A relationship IfcRelAggregates from IfcElement to IfcElement
+      Given A relationship IfcRelAggregates from IfcElement to IfcElement and following that
 
       Then The relative placement of that IfcElement must be provided by an IfcLocalPlacement entity
 
@@ -20,6 +20,6 @@ with an PlacementRelTo attribute pointing to the IfcLocalPlacement of the contai
 
       Given A model with Schema "IFC2X3" or "IFC4"
       Given An IfcElement
-      Given A relationship IfcRelAggregates from IfcElement to IfcElement
+      Given A relationship IfcRelAggregates from IfcElement to IfcElement and following that
 
       Then The PlacementRelTo attribute must point to the IfcLocalPlacement of the container element established with IfcRelAggregates relationship

--- a/features/steps/givens/attributes.py
+++ b/features/steps/givens/attributes.py
@@ -7,7 +7,11 @@ from parse_type import TypeBuilder
 from validation_handling import gherkin_ifc
 from . import ValidationOutcome, OutcomeSeverity
 
-register_type(first_or_final=TypeBuilder.make_enum({"first": 0, "final": 1 }))
+from enum import Enum, auto
+class FirstOrFinal(Enum):
+  FIRST = auto()
+  FINAL = auto()
+register_type(first_or_final=TypeBuilder.make_enum({"first": FirstOrFinal.FIRST, "final": FirstOrFinal.FINAL }))
 
 @gherkin_ifc.step("{attribute} = {value}")
 def step_impl(context, inst, attribute, value):
@@ -76,19 +80,11 @@ def step_impl(context, inst, attribute, condition, prefix):
 
 @gherkin_ifc.step('Its {ff:first_or_final} element')
 @gherkin_ifc.step('Its {ff:first_or_final} element at depth 1')
-@gherkin_ifc.step('Its {ff:first_or_final} element filtering by {filter}')
-@gherkin_ifc.step('Its {ff:first_or_final} element at depth 1 filtering by {filter}')
 def step_impl(context, inst, ff=0, filter=None):
-    def get_filter_key(attr):
-        if attr == 'id':
-            return lambda entity: entity.id() # in case of a method
-        else:
-            return lambda entity: getattr(entity, attr, None) # in case of an attribute
-
-    if ff:
-        yield ValidationOutcome(instance_id =  max(inst, key=get_filter_key(filter)) if filter else inst[-1], severity=OutcomeSeverity.PASSED)
-    else:
-        yield ValidationOutcome(instance_id =  min(inst, key=get_filter_key(filter)) if filter else inst[0], severity=OutcomeSeverity.PASSED)
+    if ff == FirstOrFinal.FINAL:
+        yield ValidationOutcome(instance_id = inst[-1], severity=OutcomeSeverity.PASSED)
+    elif ff == FirstOrFinal.FIRST:
+        yield ValidationOutcome(instance_id = inst[0], severity=OutcomeSeverity.PASSED)
 
 @gherkin_ifc.step("An IFC model")
 def step_impl(context):

--- a/features/steps/givens/attributes.py
+++ b/features/steps/givens/attributes.py
@@ -89,10 +89,3 @@ def step_impl(context, inst, ff=0, filter=None):
 @gherkin_ifc.step("An IFC model")
 def step_impl(context):
     yield ValidationOutcome(instance_id = context.model, severity=OutcomeSeverity.PASSED)
-
-
-@gherkin_ifc.step("The entity type is {expected_entity_type}")
-def step_impl(context, inst, expected_entity_type):
-    expected_entity_types = tuple(map(str.strip, expected_entity_type.split(' or ')))
-    entities = [_[0] for _ in inst if _[0].is_a() in expected_entity_types]
-    return ValidationOutcome(inst_id=tuple(entities), severity=OutcomeSeverity.PASSED)

--- a/features/steps/givens/attributes.py
+++ b/features/steps/givens/attributes.py
@@ -80,7 +80,7 @@ def step_impl(context, inst, attribute, condition, prefix):
 
 @gherkin_ifc.step('Its {ff:first_or_final} element')
 @gherkin_ifc.step('Its {ff:first_or_final} element at depth 1')
-def step_impl(context, inst, ff=0, filter=None):
+def step_impl(context, inst, ff : FirstOrFinal):
     if ff == FirstOrFinal.FINAL:
         yield ValidationOutcome(instance_id = inst[-1], severity=OutcomeSeverity.PASSED)
     elif ff == FirstOrFinal.FIRST:

--- a/features/steps/givens/relationships.py
+++ b/features/steps/givens/relationships.py
@@ -1,75 +1,65 @@
-import csv
-import os
-import re
-
-from pathlib import Path
-from utils import misc, system
+from utils import system
+from behave import register_type
+from parse_type import TypeBuilder
 
 from validation_handling import gherkin_ifc
 
 from . import ValidationOutcome, OutcomeSeverity
 
-
-@gherkin_ifc.step('A relationship {relationship} from {entity} to {other_entity}')
-def step_impl(context, entity, other_entity, relationship):
-    instances = []
-    relationships = context.model.by_type(relationship)
-    if not relationships:
-        context.applicable = False
-    else:
-        filename_related_attr_matrix = system.get_abs_path(f"resources/**/related_entity_attributes.csv")
-        filename_relating_attr_matrix = system.get_abs_path(f"resources/**/relating_entity_attributes.csv")
-        related_attr_matrix = system.get_csv(filename_related_attr_matrix, return_type='dict')[0]
-        relating_attr_matrix = system.get_csv(filename_relating_attr_matrix, return_type='dict')[0]
-        for rel in relationships:
-            regex = re.compile(r'([0-9]+=)([A-Za-z0-9]+)\(')
-            relationships_str = regex.search(str(rel)).group(2)
-            relationship_relating_attr = relating_attr_matrix.get(relationships_str)
-            relationship_related_attr = related_attr_matrix.get(relationships_str)
-            if getattr(rel, relationship_relating_attr).is_a(other_entity):
-                try:  # check if the related attribute returns a tuple/list or just a single instance
-                    iter(getattr(rel, relationship_related_attr))
-                    related_objects = getattr(rel, relationship_related_attr)
-                except TypeError:
-                    related_objects = tuple(getattr(rel, relationship_related_attr))
-                for obj in related_objects:
-                    if obj.is_a(entity):
-                        instances.append(obj)
-        for inst in instances:
-            yield ValidationOutcome(instance_id = inst, severity = OutcomeSeverity.PASSED)
+register_type(from_to=TypeBuilder.make_enum({"from": 0, "to": 1 }))
+register_type(maybe_and_following_that=TypeBuilder.make_enum({"": 0, "and following that": 1 }))
 
 
-#@nb this is awaiting the merge of https://github.com/buildingSMART/ifc-gherkin-rules/pull/37
-#now needs to be disambiguated from the above, can be removed when #37 is merged
-@gherkin_ifc.step('There exists a relationship {relationship} from {entity} to {other_entity} and following that')
-def step_impl(context, relationship, entity, other_entity):
+@gherkin_ifc.step('A relationship {relationship} {dir1:from_to} {entity} {dir2:from_to} {other_entity}')
+@gherkin_ifc.step('A relationship {relationship} exists {dir1:from_to} {entity} {dir2:from_to} {other_entity}')
+@gherkin_ifc.step('A relationship {relationship} {dir1:from_to} {entity} {dir2:from_to} {other_entity} {tail:maybe_and_following_that}')
+@gherkin_ifc.step('A *{required}* relationship {relationship} {dir1:from_to} {entity} {dir2:from_to} {other_entity} {tail:maybe_and_following_that}')
+def step_impl(context, inst, relationship, dir1, entity, dir2, other_entity, tail=0, required=False):
+    """""
+    Reference to tfk ALB999 rule https://github.com/buildingSMART/ifc-gherkin-rules/pull/37
+    """
+    assert dir1 != dir2
 
     relationships = context.model.by_type(relationship)
     instances = []
-    dirname = os.path.dirname(__file__)
-    filename_related_attr_matrix = Path(dirname).parent.parent / 'resources' / 'attribute_mapping' / 'related_entity_attributes.csv'
-    filename_relating_attr_matrix = Path(dirname).parent.parent / 'resources' / 'attribute_mapping' / 'relating_entity_attributes.csv'
-    related_attr_matrix = next(csv.DictReader(open(filename_related_attr_matrix)))
-    relating_attr_matrix = next(csv.DictReader(open(filename_relating_attr_matrix)))
+    filename_related_attr_matrix = system.get_abs_path(f"resources/**/related_entity_attributes.csv")
+    filename_relating_attr_matrix = system.get_abs_path(f"resources/**/relating_entity_attributes.csv")
+    related_attr_matrix = system.get_csv(filename_related_attr_matrix, return_type='dict')[0]
+    relating_attr_matrix = system.get_csv(filename_relating_attr_matrix, return_type='dict')[0]
 
-    for inst in context.instances:
-        for rel in relationships:
-            attr_to_entity = relating_attr_matrix.get(rel.is_a())
-            attr_to_other = related_attr_matrix.get(rel.is_a())
+    for rel in relationships:
+        attr_to_entity = relating_attr_matrix.get(rel.is_a())
+        attr_to_other = {0: v for k, v in related_attr_matrix.items() if rel.is_a(k)}.get(0)
 
-            def make_aggregate(val):
-                if not isinstance(val, (list, tuple)):
-                    val = [val]
-                return val
+        assert attr_to_entity
+        assert attr_to_other
 
+        if dir1:
+            attr_to_entity, attr_to_other = attr_to_other, attr_to_entity
+
+        def make_aggregate(val):
+            if not isinstance(val, (list, tuple)):
+                val = [val]
+            return val
+
+        for other in other_entity.split(' or '):
             to_entity = set(make_aggregate(getattr(rel, attr_to_entity)))
-            to_other = set(filter(lambda i: i.is_a(other_entity), make_aggregate(getattr(rel, attr_to_other))))
+            try:
+                to_other = set(filter(lambda i: i.is_a(other), make_aggregate(getattr(rel, attr_to_other))))
+            except RuntimeError:
+                yield ValidationOutcome(instance_id=inst, severity=OutcomeSeverity.ERROR)
 
             if v := {inst} & to_entity:
-                instances.extend(to_other)
+                if tail:
+                    instances.extend(to_other)
+                else:
+                    instances.extend(v)
 
-    for inst in instances:
-        yield ValidationOutcome(instance_id = inst, severity = OutcomeSeverity.PASSED)
+
+    if instances:
+        yield ValidationOutcome(instance_id=instances, severity=OutcomeSeverity.PASSED)
+    if not instances and required:
+        yield ValidationOutcome(instance_id=inst, severity=OutcomeSeverity.ERROR)
 
     
 

--- a/features/steps/givens/relationships.py
+++ b/features/steps/givens/relationships.py
@@ -45,7 +45,7 @@ def step_impl(context, inst, relationship, dir1, entity, dir2, other_entity, tai
         for other in other_entity.split(' or '):
             to_entity = set(make_aggregate(getattr(rel, attr_to_entity)))
             try:
-                to_other = set(filter(lambda i: i.is_a(other), make_aggregate(getattr(rel, attr_to_other))))
+                to_other = list(filter(lambda i: i.is_a(other), make_aggregate(getattr(rel, attr_to_other))))
             except RuntimeError:
                 yield ValidationOutcome(instance_id=inst, severity=OutcomeSeverity.ERROR)
 

--- a/features/steps/thens/attributes.py
+++ b/features/steps/thens/attributes.py
@@ -91,7 +91,7 @@ def step_impl(context, inst, field, file_or_model, values):
             yield ValidationOutcome(inst=inst, expected=[v.upper() for v in values], observed=misc.do_try(s.upper(), s), severity=OutcomeSeverity.ERROR)
 
 
-@gherkin_ifc.step('The {length_attribute} of the final {segment_type} must be 0')
+@gherkin_ifc.step('The {length_attribute} of the {segment_type} must be 0')
 def step_impl(context, inst, segment_type, length_attribute):
     business_logic_types = [f"IFCALIGNMENT{_}SEGMENT" for _ in ["HORIZONTAL", "VERTICAL", "CANT"]]
     if segment_type == "segment":


### PR DESCRIPTION
Modified: 

- The more standardised and tested work from gcert `'A relationship X between U and Z'` with an optional `and following that ` moved over to the current gherkin repository. 
- OJP001. Now we're stating `'and following that' ` to continue with the subsequent element (and not the initial activation instance)
- ALB015. With using the statement 'its final segment at depth 1' from the previous ALS015 rule, we're selecting the last `IfcAlignmentSegment` from context.instances, thus avoiding the previous found duplication.