### PR TITLE
Small fixes

### DIFF
--- a/features/GEM003_Unique-representation-identifier.feature
+++ b/features/GEM003_Unique-representation-identifier.feature
@@ -12,4 +12,4 @@ The rule verifies that Shape Representation identifier is unique within the prod
     Given Its attribute Representations
     Given its attribute RepresentationIdentifier
 
-    Then The values must be unique
+    Then The values must be unique at depth 1

--- a/features/GRF001_Identical-coordinate-operations.feature
+++ b/features/GRF001_Identical-coordinate-operations.feature
@@ -8,8 +8,8 @@ The rule verifies that the same coordinate system is used within an IFC model an
   Scenario: IfcGeometricRepresentationContext
 
     Given A model with Schema "IFC4.3"
-    Given All instances of IfcGeometricRepresentationContext without subtypes
+    Given An IfcGeometricRepresentationContext without subtypes
     Given Its Attribute HasCoordinateOperation
     Given Its values excluding SourceCRS
     
-    Then The values must be identical at depth 1
+    Then The values must be identical within the model

--- a/features/rule_creation_protocol/protocol.py
+++ b/features/rule_creation_protocol/protocol.py
@@ -191,7 +191,7 @@ class RuleCreationConventions(ConfiguredBaseModel):
 
         normalized_path = os.path.normpath(value)
         """Check if test file is located in the ifc-gherkin-rules\\test\\files directory"""
-        if not (('ifc-gherkin-rules\\test\\files\\' in normalized_path) or ('ifc-gherkin-rules/test/files/' in normalized_path)):
+        if not (('ifc-gherkin-rules\\test\\files\\' in normalized_path) or ('ifc-gherkin-rules/test/files/' in normalized_path) or ('ifc_gherkin_rules\\test\\files\\' in normalized_path) or ('ifc_gherkin_rules/test/files/' in normalized_path)):
             raise ProtocolError(
                 value=value,
                 message=f"The test files are to be placed in the ifc-gherkin-rules/test/files/ directory. Currently it's placed: {normalized_path}"

--- a/features/rule_creation_protocol/protocol.py
+++ b/features/rule_creation_protocol/protocol.py
@@ -189,9 +189,10 @@ class RuleCreationConventions(ConfiguredBaseModel):
     @field_validator('filename')
     def validate_test_filename(cls, value):
 
-        normalized_path = os.path.normpath(value)
+        # replace the backslashes for Windows systems, and replace underscores with dashes for when running as submodule in validate repo
+        normalized_path = os.path.normpath(value).replace('\\', '/').replace('_', '-')
         """Check if test file is located in the ifc-gherkin-rules\\test\\files directory"""
-        if not (('ifc-gherkin-rules\\test\\files\\' in normalized_path) or ('ifc-gherkin-rules/test/files/' in normalized_path) or ('ifc_gherkin_rules\\test\\files\\' in normalized_path) or ('ifc_gherkin_rules/test/files/' in normalized_path)):
+        if not 'ifc-gherkin-rules/test/files' in normalized_path:
             raise ProtocolError(
                 value=value,
                 message=f"The test files are to be placed in the ifc-gherkin-rules/test/files/ directory. Currently it's placed: {normalized_path}"

--- a/features/steps/givens/entities.py
+++ b/features/steps/givens/entities.py
@@ -10,10 +10,7 @@ from . import ValidationOutcome, OutcomeSeverity
 
 
 @gherkin_ifc.step("An {entity_opt_stmt}")
-@gherkin_ifc.step("All {insts} of {entity_opt_stmt}")
 def step_impl(context, entity_opt_stmt, insts=False):
-    within_model = (insts == 'instances')  # True for given statement containing {insts}
-
     entity2 = pyparsing.Word(pyparsing.alphas)('entity')
     sub_stmts = ['with subtypes', 'without subtypes', pyparsing.LineEnd()]
     incl_sub_stmt = functools.reduce(operator.or_, [misc.rtrn_pyparse_obj(i) for i in sub_stmts])('include_subtypes')
@@ -27,7 +24,6 @@ def step_impl(context, entity_opt_stmt, insts=False):
     except:
         instances = []
 
-    context.within_model = getattr(context, 'within_model', True) and within_model
     if instances:
         context.applicable = getattr(context, 'applicable', True)
     else:

--- a/features/steps/thens/alignment.py
+++ b/features/steps/thens/alignment.py
@@ -173,8 +173,9 @@ def ala003_activation_inst(inst, context) -> Union[ifcopenshell.entity_instance 
 @gherkin_ifc.step(
     'A representation by {ifc_rep_criteria} requires the {existence:absence_or_presence} of {entities} in the business logic')
 def step_impl(context, inst, ifc_rep_criteria, existence, entities):
-    for align_ent in context.instances:
-        align = ifc43.entities.Alignment().from_entity(align_ent)
+    # @nb if True is just temporarily here to keep indentation the same during review
+    if True:
+        align = ifc43.entities.Alignment().from_entity(inst)
         match (ifc_rep_criteria, existence, entities):
             case ("IfcSegmentedReferenceCurve", "presence", "IfcAlignmentCant"):
                 if align.segmented_reference_curve is not None:

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -283,14 +283,14 @@ def handle_then(context, fn, **kwargs):
             return False
 
         if context.is_global_rule:
-            return apply_then_operation(fn, [items], context, current_path=None, **kwargs)
+            return apply_then_operation(fn, items, context, current_path=None, **kwargs)
         elif should_apply(items, depth):
             return apply_then_operation(fn, items, context, current_path, **kwargs)
         elif is_nested(items):
             new_depth = depth if depth > 0 else 0
             return type(items)(map_then_state(v, fn, context, current_path + [i], new_depth, **kwargs) for i, v in enumerate(items))
         else:
-            return apply_then_operation(fn, items, context, **kwargs)
+            return apply_then_operation(fn, items, context, current_path, **kwargs)
     map_then_state(instances, fn, context, depth = 1 if 'at depth 1' in context.step.name.lower() else 0, **kwargs)
 
     # evokes behave error
@@ -388,7 +388,7 @@ def expected_behave_output(context: Context, data: Any, is_observed : bool = Fal
                 # step name is a good proxy for expected, but not for observed
                 return context.step.name
         case str():
-            if data in [x.name() for x in ifcopenshell.ifcopenshell_wrapper.schema_by_name(context.model.schema).entities()]:
+            if data in [x.name() for x in ifcopenshell.ifcopenshell_wrapper.schema_by_name(context.model.schema_identifier).entities()]:
                 return {'entity': data} # e.g. 'the type must be IfcCompositeCurve'
             else:
                 return {'value': data} # e.g. "The value must be 'Body'"


### PR DESCRIPTION
I wanted to eliminate usage of `context.instances` in rules because I think these are not fully migrated after the decorator work, most likely resulting in duplicated results. In the meantime I was able to remove the `within_model` hack, substituting that with the more modern global_rule hack,. One use of `schema` should be `schema_identifier`. 