### PR TITLE
quickfix/SPS007 fixes

### DIFF
--- a/features/SPS007_Spatial-containment.feature
+++ b/features/SPS007_Spatial-containment.feature
@@ -4,7 +4,7 @@
 @E00040
 
 Feature: SPS007 - Spatial Containment
-The rule verifies that spatial containment via IfcRelContainedInSpatialStructure is utilised in accordance with [Concept Template 4.1.5.13.2](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/concepts/Object_Connectivity/Spatial_Structure/Spatial_Containment/content.html)
+The rule verifies that spatial containment via IfcRelContainedInSpatialStructure is utilised in accordance with Contept Template for Spatial Containment
 
     Scenario Outline: Instances of IfcAnnotation and IfcGrid must be contained within a spatial structure
 

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -252,9 +252,18 @@ def execute_step(fn):
 
     return inner
 
+def display_entity_instance(inst: ifcopenshell.entity_instance) -> str : 
+    """
+    Displays a message for an entity instance within the expected and observed table.
+    For example, an instance of IfcAlignment would be displayed as:
+    '(Expected/Observed) = IfcAlignment(#27)'
+    """
+    return misc.do_try(lambda: f'{inst.is_a()}(#{inst.id()})', getattr(inst, 'GlobalId', inst.id()))
+
+
 def serialize_item(item: Any) -> Any:
     if isinstance(item, ifcopenshell.entity_instance):
-        return getattr(item, 'GlobalId', item.is_a())
+        return display_entity_instance(item)
     else:
         return item
 
@@ -287,7 +296,7 @@ def expected_behave_output(context: Context, data: Any, is_observed : bool = Fal
             else:
                 return {'value': data} # e.g. "The value must be 'Body'"
         case ifcopenshell.entity_instance():
-            return {'instance': f"{data.is_a()}({getattr(data, 'GlobalId', data.id())})"}
+            return {'instance': display_entity_instance(data)}
         case dict():
             # mostly for the pse001 rule, which already yields dicts
             return data


### PR DESCRIPTION
PR:
- Simplifies the `SPS007` feature description due to parsing errors on the platform.
- Displays the entity type with its ID in the entity's string representation for the observed/expected column.

![image](https://github.com/buildingSMART/ifc-gherkin-rules/assets/54070862/0438db8c-c7d8-445f-a069-fa45045f2b55)

Also applies to other rules. For instance, `OJP001`
![image](https://github.com/buildingSMART/ifc-gherkin-rules/assets/54070862/12867969-f33a-4377-96ff-3a4a7eaa4e1d)

