### PR TITLE
fix/ivs7-ifcopenshell-versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install behave pytest tabulate pyparsing sqlalchemy numpy pydantic pydot sqlalchemy_utils django python-dotenv deprecated pandas
-        wget -O /tmp/ifcopenshell_python.zip https://s3.amazonaws.com/ifcopenshell-builds/ifcopenshell-python-`python3 -c 'import sys;print("".join(map(str, sys.version_info[0:2])))'`-v0.7.0-f7c03db-linux64.zip
+        wget -O /tmp/ifcopenshell_python.zip https://s3.amazonaws.com/ifcopenshell-builds/ifcopenshell-python-`python3 -c 'import sys;print("".join(map(str, sys.version_info[0:2])))'`-v0.8.0-90ae709-linux64.zip
         mkdir -p `python3 -c 'import site; print(site.getusersitepackages())'`
         unzip -d `python3 -c 'import site; print(site.getusersitepackages())'` /tmp/ifcopenshell_python.zip
     - name: Lint with flake8

--- a/features/rule_creation_protocol/ifcopenshell_versioning.py
+++ b/features/rule_creation_protocol/ifcopenshell_versioning.py
@@ -1,0 +1,73 @@
+import requests
+import yaml
+import re
+from packaging import version
+import ifcopenshell
+
+def recent_ifcopenshell_version():
+    branches = requests.get("https://api.github.com/repos/IfcOpenBot/IfcOpenShell/branches").json()
+    versions = [branch['name'] for branch in branches if re.compile(r'^v\d+\.\d+\.\d+$').match(branch['name'])]
+    versions.sort(key=version.parse)
+    return versions[-1]
+
+def latest_ifcopenshell_build_commit():
+    try:
+        ifcopenshell_version = recent_ifcopenshell_version()
+    except:
+        return None # e.g. maximum api requests reached
+    url = f"https://api.github.com/repos/IfcOpenBot/IfcOpenShell/commits?sha={ifcopenshell_version}"
+    response = requests.get(url)
+    commits = response.json()
+
+    for commit in commits:
+        for comment in  requests.get(commit['comments_url']).json():
+            if 'ifcopenshell-builds' in comment['body'] and 'IfcOpenBot' in comment['user']['login']:
+                commit_hash = commit['sha'][:7]
+                return f"{ifcopenshell_version}-{commit_hash}"
+            
+def get_commit_hash_from_ci_yml(file_path):
+    with open(file_path, 'r') as file:
+        ci_config = yaml.safe_load(file)
+
+    steps = ci_config['jobs']['build-linux']['steps']
+    wget_command = None
+    for step in steps:
+        if 'run' in step and 'wget' in step['run']:
+            wget_command = step['run']
+            break
+
+    match = re.search(r'ifcopenshell-python-[^/]+-v([0-9]+\.[0-9]+\.[0-9]+)-([a-f0-9]+)-linux64.zip', wget_command)
+    if match:
+        return f"v{match.group(1)}-{match.group(2)}"
+    else:
+        return None
+
+def update_ci_yml_with_latest_hash(file_path, latest_version):
+    with open(file_path, 'r') as file:
+        ci_content = file.read()
+
+    updated_content = re.sub(
+        r'(ifcopenshell-python-[^/]+-v)([0-9]+\.[0-9]+\.[0-9]+)-([a-f0-9]+)(-linux64.zip)',
+        rf'\g<1>{latest_version[1:]}\g<4>',
+        ci_content
+    )
+
+    with open(file_path, 'w') as file:
+        file.write(updated_content)
+
+
+def update_ifcopenshell_version():
+    ci_yml_path = '.github/workflows/ci.yml'
+    ifcopenshell_build_hash = {
+        'latest_build' : latest_ifcopenshell_build_commit(),
+        'local': ifcopenshell.version[:7],
+        'ci_cd': get_commit_hash_from_ci_yml(ci_yml_path)
+    }
+
+    if ifcopenshell_build_hash['latest_build'] != ifcopenshell_build_hash['ci_cd']:
+        if ifcopenshell_build_hash['ci_cd'] and ifcopenshell_build_hash['latest_build']: # only update version once every test
+            update_ci_yml_with_latest_hash(ci_yml_path, ifcopenshell_build_hash['latest_build'])
+            print('ifcopenshell version updated')
+
+if __name__ == '__main__':
+    update_ifcopenshell_version()

--- a/features/rule_creation_protocol/protocol.py
+++ b/features/rule_creation_protocol/protocol.py
@@ -10,6 +10,7 @@ from .validation_helper import ValidatorHelper, ParsePattern
 from .duplicate_registry import Registry
 from .errors import ProtocolError
 from .config import ConfiguredBaseModel
+from .ifcopenshell_versioning import update_ifcopenshell_version
 
 from typing import Any, Optional
 
@@ -310,6 +311,9 @@ def enforce(convention_attrs : dict = {}, testing_attrs : dict = {}):
     It can work in a testing mode when a testing dictionary is provided.
     """
     attrs = convention_attrs or testing_attrs
+
+    #if relevant, update ifcopenshell version in yml file
+    update_ifcopenshell_version()
 
     feature_obj = {
         'feature': {


### PR DESCRIPTION
> being IfcOpenShell a dependency this is a reminder to make sure the VS uses the correct version…once updated (don’t think it’s an automated process, I’m sure we need to do something)

The automated check is currently placed at the beginning of the protocol errors, which means it runs for every local test. A few alternatives:

-  Completely manual: No automated check. Instead, manually run the script periodically (e.g., by executing `python3 update_ifcopenshell_versioning.py`). This approach avoids unnecessary API calls but we'll have to remember to execute this once in a while.

- Inside the Protocol Error: The automated check runs within the protocol error handling. However, this can be inefficient as it executes for multiple scenarios, quickly reaching the API rate limit.

- Within generate_markdown.py: This check would run each time a new rule is created. The downside is that it might not be tested regularly when we're not making new rules.