### PR TITLE
Fix/Psj002; consider inheritance (IVS-46)

### DIFF
--- a/features/steps/thens/values.py
+++ b/features/steps/thens/values.py
@@ -38,13 +38,8 @@ def step_impl(context, inst, i, csv_file):
         else:
             return instance in valid_values
 
-    if isinstance(inst, (list, tuple)):
-        invalid_values = [i for i in inst if not is_valid_instance(i)]
-        for value in invalid_values:
-            yield ValidationOutcome(inst=inst, expected=valid_values, observed=value, severity=OutcomeSeverity.ERROR)
-    else:
-        if not is_valid_instance(inst):
-            yield ValidationOutcome(inst=inst, expected=valid_values, observed=inst, severity=OutcomeSeverity.ERROR)
+    if not is_valid_instance(inst):
+        yield ValidationOutcome(inst=inst, expected=valid_values, observed=inst, severity=OutcomeSeverity.ERROR)
 
 @gherkin_ifc.step('At least "{num:d}" value must {constraint}')
 @gherkin_ifc.step('At least "{num:d}" values must {constraint}')


### PR DESCRIPTION
Solving issue https://github.com/buildingSMART/validate/issues/74

instead of 
`inst.is_a() in csv_values`

`any(inst.is_a(x) for x in csv_values`

![image](https://github.com/buildingSMART/ifc-gherkin-rules/assets/54070862/09692bac-379a-4934-a2e5-f83ead8c7541)
