### PR TITLE
IVS-43 - Fix/update error message GEM051

### DIFF
--- a/features/GEM051_Presence-of-geometric-context.feature
+++ b/features/GEM051_Presence-of-geometric-context.feature
@@ -22,5 +22,5 @@ The rule verifies that a geometric context is present in the model.
     Given An IfcContext
     Given Its attribute RepresentationContexts
 
-    Then  Assert existence 
+    Then Assert existence 
     Then Its entity type is 'IfcGeometricRepresentationContext' including subtypes

--- a/features/steps/givens/attributes.py
+++ b/features/steps/givens/attributes.py
@@ -81,8 +81,8 @@ def step_impl(context, inst, comparison_op, attribute, value, tail=SubTypeHandli
     entity_is_applicable = False
     observed_v = ()
     if attribute.lower() in ['its type', 'its entity type']: # it's entity type is a special case using ifcopenshell 'is_a()' func
+        observed_v = misc.do_try(lambda : inst.is_a(), ())
         if pred(check_entity_type(inst, value, tail), True):
-            observed_v = inst.is_a()
             entity_is_applicable = True
 
     else:

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -133,6 +133,9 @@ def handle_then(context, fn, **kwargs):
                 return
             top_level_index = current_path[0] if current_path else None
             activation_inst = inst if not current_path or activation_instances[top_level_index] is None else activation_instances[top_level_index]
+
+            if "GEM051" in context.feature.name and context.is_global_rule:
+                activation_inst = activation_instances[0]
             if isinstance(activation_inst, ifcopenshell.file):
                 activation_inst = None  # in case of blocking IFC101 check, for safety set explicitly to None
 

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -133,7 +133,7 @@ def handle_then(context, fn, **kwargs):
                 return
             top_level_index = current_path[0] if current_path else None
             activation_inst = inst if not current_path or activation_instances[top_level_index] is None else activation_instances[top_level_index]
-
+#TODO: refactor into a more general solution that works for all rules
             if "GEM051" in context.feature.name and context.is_global_rule:
                 activation_inst = activation_instances[0]
             if isinstance(activation_inst, ifcopenshell.file):


### PR DESCRIPTION
We're performing attribute lookups for both Given as well as Then statements.  `Observed` was calculated after a matching expected entity type and the entity type found for the value. This is however not sufficient if we check for mismatching entity types. In this case, we want to display the mismatching entity type and therefore have to save this before the actual matching (as everything after the actual matching will not be reached; it is incorrect). 

This will display the false entity type for GEM051
![image](https://github.com/user-attachments/assets/5b9a2ad3-0c55-4f9b-ad58-021f4d69a3b1)
