### PR TITLE
feature/IVS-65 functional part commin step impl

### DIFF
--- a/features/rule_creation_protocol/protocol.py
+++ b/features/rule_creation_protocol/protocol.py
@@ -147,11 +147,11 @@ class RuleCreationConventions(ConfiguredBaseModel):
 
     @field_validator('description')
     def validate_description(cls, value=list) -> list:
-        """must include a description of the rule that start with "The rule verifies that..."""  # allow for comma's
-        if not any(value.startswith(f"{prefix} rule verifies{optional_comma} that") for prefix in ("This", "The") for optional_comma in ("", ",")):
+        """must include a description of the rule that start with "The rule verifies ..."""  # allow for comma's
+        if not any(value.startswith(f"{prefix} rule verifies{optional_comma}") for prefix in ("This", "The") for optional_comma in ("", ",")):
             raise ProtocolError(
                 value=value,
-                message=f"The description must start with 'The rule verifies that', it now starts with {value}"
+                message=f"The description must start with 'The rule verifies', it now starts with {value}"
             )
         return value
 

--- a/features/steps/thens/existance.py
+++ b/features/steps/thens/existance.py
@@ -69,7 +69,7 @@ def step_impl(context, inst):
 
     if not any(recursive_flatten(inst)):
         expected = get_previous_step_before_assertion(context)
-        yield ValidationOutcome(instance_id=inst, expected = expected, observed='Nonexistent', severity = OutcomeSeverity.ERROR)
+        yield ValidationOutcome(instance_id=inst, expected=expected, observed='Nonexistent', severity=OutcomeSeverity.ERROR)
 
 
 @gherkin_ifc.step("The IFC model contains information on {functional_part_description}")

--- a/features/steps/thens/existance.py
+++ b/features/steps/thens/existance.py
@@ -70,3 +70,9 @@ def step_impl(context, inst):
     if not any(recursive_flatten(inst)):
         expected = get_previous_step_before_assertion(context)
         yield ValidationOutcome(instance_id=inst, expected = expected, observed='Nonexistent', severity = OutcomeSeverity.ERROR)
+
+@gherkin_ifc.step("The IFC model contains information on {functional_part_description}")
+def step_impl(context, inst, functional_part_description):
+   # This rule is designed to always pass and is used solely to trigger the activation of the rule 
+    # if an instance linked to the functional part is present.
+    return []

--- a/features/steps/thens/existance.py
+++ b/features/steps/thens/existance.py
@@ -71,8 +71,9 @@ def step_impl(context, inst):
         expected = get_previous_step_before_assertion(context)
         yield ValidationOutcome(instance_id=inst, expected = expected, observed='Nonexistent', severity = OutcomeSeverity.ERROR)
 
+
 @gherkin_ifc.step("The IFC model contains information on {functional_part_description}")
 def step_impl(context, inst, functional_part_description):
    # This rule is designed to always pass and is used solely to trigger the activation of the rule 
     # if an instance linked to the functional part is present.
-    return []
+    yield ValidationOutcome(inst=inst, severity=OutcomeSeverity.PASSED)

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -164,19 +164,19 @@ def handle_then(context, fn, **kwargs):
 
                 context.gherkin_outcomes.append(validation_outcome)
 
-                if not step_results:
+            if not step_results:
 
-                    validation_outcome = ValidationOutcome(
-                        outcome_code=ValidationOutcomeCode.PASSED,  # todo @gh "Rule passed" # deactivated until code table is added to django model
-                        observed=None,
-                        expected=None,
-                        feature=context.feature.name,
-                        feature_version=misc.define_feature_version(context),
-                        severity=OutcomeSeverity.PASSED,
-                        instance_id = safe_method_call(activation_inst, 'id', None),
-                        validation_task_id=context.validation_task_id
-                    )
-                    context.gherkin_outcomes.append(validation_outcome)
+                validation_outcome = ValidationOutcome(
+                    outcome_code=ValidationOutcomeCode.PASSED,  # todo @gh "Rule passed" # deactivated until code table is added to django model
+                    observed=None,
+                    expected=None,
+                    feature=context.feature.name,
+                    feature_version=misc.define_feature_version(context),
+                    severity=OutcomeSeverity.PASSED,
+                    instance_id = safe_method_call(activation_inst, 'id', None),
+                    validation_task_id=context.validation_task_id
+                )
+                context.gherkin_outcomes.append(validation_outcome)
 
 
 


### PR DESCRIPTION
See comments at https://github.com/buildingSMART/ifc-gherkin-rules/pull/239#discussion_r1685865257 

This task is relatively small, but it's probably best to avoid adding it to every new rule created to activate the functional part. This way, if we need to make changes to this code in the future, we won't have to adjust every affected PR.

Further changes; 
- We can be more lenient in the protocol check regarding the feature description starting with '`The rule verifies that`'. Rather, `'the rule verifies'` is sufficient and gives us a bit more room. See https://github.com/buildingSMART/ifc-gherkin-rules/pull/244/commits/ef4cbc2b3b71b5621daf13ef0c7e25a01bf09667
- Fixed a small error, but with big consequences. The distinction between passed and activated was not reached in the handling script because of wrong indentation. Fixed in https://github.com/buildingSMART/ifc-gherkin-rules/pull/244/commits/73ab399d24ca4fecbb07cef693c5317cea760c80