### PR TITLE
IVS-84/Fix - PSE001 stricter prefix matching

### DIFF
--- a/features/PSE001_Standard-properties-and-property-sets-validation.feature
+++ b/features/PSE001_Standard-properties-and-property-sets-validation.feature
@@ -1,6 +1,6 @@
 @implementer-agreement
 @PSE
-@version2
+@version3
 @E00020
 Feature: PSE001 - Standard properties and property sets validation
 The rule verifies that each IfcPropertySet starting with Pset is defined correctly.

--- a/test/files/pse001/fail-pse001-incorrect_pset_name_case_mix.ifc
+++ b/test/files/pse001/fail-pse001-incorrect_pset_name_case_mix.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2024-05-09T13:24:48',(),(),'IfcOpenShell v0.7.0-f7c03db75','IfcOpenShell v0.7.0-f7c03db75','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCACTUATOR('2tnEUUrG92tBGJmIuVXcvm',$,$,$,$,$,$,$,.ELECTRICACTUATOR.);
+#2=IFCPROPERTYSINGLEVALUE('ActuatorInputPower',$,IFCPOWERMEASURE(1.),$);
+#3=IFCPROPERTYSET('1jil4Mbov5lemQ5v8UPWBu',$,'PSeT ActuatorTypeElectricActuator',$,(#2));
+#4=IFCRELDEFINESBYPROPERTIES('0ZEllolWD0XO1HtFAZ9ZDf',$,$,$,(#1),#3);
+ENDSEC;
+END-ISO-10303-21;

--- a/test/files/pse001/fail-pse001-incorrect_pset_name_hyphen.ifc
+++ b/test/files/pse001/fail-pse001-incorrect_pset_name_hyphen.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2024-05-09T13:24:48',(),(),'IfcOpenShell v0.7.0-f7c03db75','IfcOpenShell v0.7.0-f7c03db75','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCACTUATOR('2tnEUUrG92tBGJmIuVXcvm',$,$,$,$,$,$,$,.ELECTRICACTUATOR.);
+#2=IFCPROPERTYSINGLEVALUE('ActuatorInputPower',$,IFCPOWERMEASURE(1.),$);
+#3=IFCPROPERTYSET('1jil4Mbov5lemQ5v8UPWBu',$,'Pset-ActuatorTypeElectricActuator',$,(#2));
+#4=IFCRELDEFINESBYPROPERTIES('0ZEllolWD0XO1HtFAZ9ZDf',$,$,$,(#1),#3);
+ENDSEC;
+END-ISO-10303-21;

--- a/test/files/pse001/fail-pse001-incorrect_pset_name_lowercases.ifc
+++ b/test/files/pse001/fail-pse001-incorrect_pset_name_lowercases.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2024-05-09T13:24:48',(),(),'IfcOpenShell v0.7.0-f7c03db75','IfcOpenShell v0.7.0-f7c03db75','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCACTUATOR('2tnEUUrG92tBGJmIuVXcvm',$,$,$,$,$,$,$,.ELECTRICACTUATOR.);
+#2=IFCPROPERTYSINGLEVALUE('ActuatorInputPower',$,IFCPOWERMEASURE(1.),$);
+#3=IFCPROPERTYSET('1jil4Mbov5lemQ5v8UPWBu',$,'pset_ActuatorTypeElectricActuator',$,(#2));
+#4=IFCRELDEFINESBYPROPERTIES('0ZEllolWD0XO1HtFAZ9ZDf',$,$,$,(#1),#3);
+ENDSEC;
+END-ISO-10303-21;

--- a/test/files/pse001/fail-pse001-incorrect_pset_name_space.ifc
+++ b/test/files/pse001/fail-pse001-incorrect_pset_name_space.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2024-05-09T13:24:48',(),(),'IfcOpenShell v0.7.0-f7c03db75','IfcOpenShell v0.7.0-f7c03db75','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCACTUATOR('2tnEUUrG92tBGJmIuVXcvm',$,$,$,$,$,$,$,.ELECTRICACTUATOR.);
+#2=IFCPROPERTYSINGLEVALUE('ActuatorInputPower',$,IFCPOWERMEASURE(1.),$);
+#3=IFCPROPERTYSET('1jil4Mbov5lemQ5v8UPWBu',$,'Pset ActuatorTypeElectricActuator',$,(#2));
+#4=IFCRELDEFINESBYPROPERTIES('0ZEllolWD0XO1HtFAZ9ZDf',$,$,$,(#1),#3);
+ENDSEC;
+END-ISO-10303-21;

--- a/test/files/pse001/fail-pse001-incorrect_pset_name_uppercase.ifc
+++ b/test/files/pse001/fail-pse001-incorrect_pset_name_uppercase.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2024-05-09T13:24:48',(),(),'IfcOpenShell v0.7.0-f7c03db75','IfcOpenShell v0.7.0-f7c03db75','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCACTUATOR('2tnEUUrG92tBGJmIuVXcvm',$,$,$,$,$,$,$,.ELECTRICACTUATOR.);
+#2=IFCPROPERTYSINGLEVALUE('ActuatorInputPower',$,IFCPOWERMEASURE(1.),$);
+#3=IFCPROPERTYSET('1jil4Mbov5lemQ5v8UPWBu',$,'PSET_ActuatorTypeElectricActuator',$,(#2));
+#4=IFCRELDEFINESBYPROPERTIES('0ZEllolWD0XO1HtFAZ9ZDf',$,$,$,(#1),#3);
+ENDSEC;
+END-ISO-10303-21;


### PR DESCRIPTION
The rule has been made stricter to ensure that incorrect property set names now trigger the rule and produce an error. Previously, this activation was not case-sensitive, leading to false positives with the following examples:
- `pset_Wallcommon`
- `PSET_Wallcommon`

For the property set `Pset Wallcommon`, the rule still activates and results in an error as intended.

Additionally:
- An option has been added to check for literal values, allowing a rule to be activated or validated with the same statement. This does not apply to the current rule, where we want activation to be broad while ensuring validation is case-sensitive.
- Several test files have been added to verify these changes.
