### PR TITLE
Always emit N/A outcomes; they are not written to db when higher severity outcomes exist

### DIFF
--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -229,21 +229,20 @@ def execute_step(fn):
 
         Data is circulated using the 'behave-context' and is ultimately stored in the database, as 'ValidationOutcome' corresponds to a database column.
         """
+        # this basically serves as placeholder, later only the highest severity
+        # outcomes are retained, so the state is initiated to NOT_APPLICABLE
+        validation_outcome = ValidationOutcome(
+            outcome_code=ValidationOutcomeCode.NOT_APPLICABLE,  # "NOT_APPLICABLE", Given statement with schema/mvd check  # deactivated until code table is added to django model
+            observed=None,
+            expected=None,
+            feature=context.feature.name,
+            feature_version=misc.define_feature_version(context),
+            severity=OutcomeSeverity.NOT_APPLICABLE,
+            validation_task_id=context.validation_task_id
+        )
+        context.gherkin_outcomes.append(validation_outcome)
 
-        if not getattr(context, 'applicable', True):
-            validation_outcome = ValidationOutcome(
-                outcome_code=ValidationOutcomeCode.NOT_APPLICABLE,  # "NOT_APPLICABLE", Given statement with schema/mvd check  # deactivated until code table is added to django model
-                observed=None,
-                expected=None,
-                feature=context.feature.name,
-                feature_version=misc.define_feature_version(context),
-                severity=OutcomeSeverity.NOT_APPLICABLE,
-                validation_task_id=context.validation_task_id
-            )
-            context.gherkin_outcomes.append(validation_outcome)
-
-        else: # applicability is set to True
-
+        if getattr(context, 'applicable', True):
             step_type = context.step.step_type
             if step_type.lower() == 'given': # behave prefers lowercase, but accepts both
                 handle_given(context, fn, **kwargs)


### PR DESCRIPTION
Not sure whether tests pass on this. Please have a look @Ghesselink but we shouldn't depend on contexr.applicable for setting the initial n/a state. This context.applicable is very likely to be true, only in case of mvd/schema related things it can be false. Whereas what we care about for the state in the DB is the selected instances at the time of the first then statement.