### PR TITLE
IVS-77 - Always include at least one Validation Outcome

### DIFF
--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -251,20 +251,18 @@ def execute_step(fn):
         Data is circulated using the 'behave-context' and is ultimately stored in the database, as 'ValidationOutcome' corresponds to a database column.
         """
 
-        if not getattr(context, 'applicable', True):
-            validation_outcome = ValidationOutcome(
-                outcome_code=ValidationOutcomeCode.NOT_APPLICABLE,  # "NOT_APPLICABLE", Given statement with schema/mvd check  # deactivated until code table is added to django model
-                observed=None,
-                expected=None,
-                feature=context.feature.name,
-                feature_version=misc.define_feature_version(context),
-                severity=OutcomeSeverity.NOT_APPLICABLE,
-                validation_task_id=context.validation_task_id
-            )
-            context.gherkin_outcomes.append(validation_outcome)
+        validation_outcome = ValidationOutcome(
+            outcome_code=ValidationOutcomeCode.NOT_APPLICABLE,  # "NOT_APPLICABLE", Given statement with schema/mvd check  # deactivated until code table is added to django model
+            observed=None,
+            expected=None,
+            feature=context.feature.name,
+            feature_version=misc.define_feature_version(context),
+            severity=OutcomeSeverity.NOT_APPLICABLE,
+            validation_task_id=context.validation_task_id
+        )
+        context.gherkin_outcomes.append(validation_outcome)
 
-        else: # applicability is set to True
-
+        if getattr(context, 'applicable', True):
             step_type = context.step.step_type
             if step_type.lower() == 'given': # behave prefers lowercase, but accepts both
                 handle_given(context, fn, **kwargs)


### PR DESCRIPTION
We currently have two mechanisms to prevent Behave from executing subsequent steps:

However, the platform does not display a rule if:

- Empty List: If a list is empty, the following steps will always yield empty results.
- `context.applicable `Variable: This is used to skip steps that are irrelevant, such as when a schema doesn't apply.

This is not the desired behavior. Instead, we should always log a ValidationOutcome with a status of "NotApplicable." Since the platform searches for the maximum severity, adding this outcome will not affect other results negatively.
This ensures that all rules are displayed for every uploaded file. 