### PR TITLE
IVS-115 - Confusing Error Message

### DIFF
--- a/features/SPS007_Spatial-containment.feature
+++ b/features/SPS007_Spatial-containment.feature
@@ -4,7 +4,7 @@
 @E00040
 
 Feature: SPS007 - Spatial Containment
-The rule verifies that spatial containment via IfcRelContainedInSpatialStructure is utilised in accordance with Contept Template for Spatial Containment
+The rule verifies that spatial containment via IfcRelContainedInSpatialStructure is utilised in accordance with Concept Template for Spatial Containment
 
     Scenario Outline: Instances of IfcAnnotation and IfcGrid must be contained within a spatial structure
 

--- a/features/steps/givens/attributes.py
+++ b/features/steps/givens/attributes.py
@@ -101,7 +101,7 @@ def step_impl(context, inst, comparison_op, attribute, value, tail=SubTypeHandli
         yield ValidationOutcome(instance_id=inst, severity = OutcomeSeverity.PASSED)
     else: # in case of a Then statement
         yield ValidationOutcome(instance_id=inst,
-                                expected = f"{'not ' if comparison_op == ComparisonOperator.NOT_EQUAL or value == () else ''}{'empty' if value == () else value}", 
+                                expected = f"{'not ' if comparison_op == ComparisonOperator.NOT_EQUAL else ''}{'empty' if value == () else value}", 
                                 observed = 'empty' if observed_v == () else observed_v, severity = OutcomeSeverity.ERROR)
 
 


### PR DESCRIPTION
Fix mistake in empty/not empty string. We should rely on `ComparisonOperatior` enum for inserting 'not' in string. 

From 
![image](https://github.com/user-attachments/assets/d9c4a1d9-9c0c-4166-97c3-4d5e8a3da7e5)

To 
![image](https://github.com/user-attachments/assets/e31c562e-f08a-4626-bdc3-6d19da70d7eb)

Also applies to IFC102, e.g. 
![image](https://github.com/user-attachments/assets/a8dec12c-198e-4d51-b84a-4ca9a04badbb)

For attributes, instead of using this step implementation, we tend to rely on (e.g. [ALS005](https://github.com/buildingSMART/ifc-gherkin-rules/blob/e049f834960fe8e66d3a12fcfecfa2fa464716ea/features/ALS005_Alignment-shape-representation.feature#L24))
`The value for attribute X must be Y`
This is identical to
`X is Y`