### PR TITLE
IVS-135 Fix/Enforce tag hierarchy

### DIFF
--- a/features/ALS004_Alignment-segment-shape-representation.feature
+++ b/features/ALS004_Alignment-segment-shape-representation.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version1
 Feature: ALS004 - Alignment segment shape representation
 The rule verifies that each IfcAlignmentSegment uses correct representation.

--- a/features/ALS005_Alignment-shape-representation.feature
+++ b/features/ALS005_Alignment-shape-representation.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version1
 Feature: ALS005 - Alignment shape representation
 The rule verifies that each IfcAlignment uses correct representation.

--- a/features/ALS006_Alignment-horizontal-shape-representation.feature
+++ b/features/ALS006_Alignment-horizontal-shape-representation.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version1
 Feature: ALS006 - Alignment horizontal shape representation
 The rule verifies that IfcAlignmentHorizontal is represented correctly with representation type Curve2D and representation item either IfcCompositeCurve or IfcIndexedPolycurve or IfcPolyline.

--- a/features/ALS007_Alignment-vertical-shape-representation.feature
+++ b/features/ALS007_Alignment-vertical-shape-representation.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version2
 Feature: ALS007 - Alignment vertical shape representation
 The rule verifies that IfcAlignmentVertical is represented correctly with representation type Curve3D and representation item IfcGradientCurve.

--- a/features/ALS008_Alignment-cant-shape-representation.feature
+++ b/features/ALS008_Alignment-cant-shape-representation.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version1
 Feature: ALS008 - Alignment cant shape representation
 The rule verifies that IfcAlignmentCant is represented correctly with representation type Curve3D and representation item IfcSegmentedReferenceCurve.

--- a/features/ALS010_Alignment-segment-shape-representation-has-the-correct-number-of-items.feature
+++ b/features/ALS010_Alignment-segment-shape-representation-has-the-correct-number-of-items.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version1
 @E00040
 Feature: ALS010 - Alignment segment shape representation has the correct number of items

--- a/features/ALS011_Alignment-segment-entity-type-consistency.feature
+++ b/features/ALS011_Alignment-segment-entity-type-consistency.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version1
 @E00010
 

--- a/features/ALS012_Alignment-segment-start-and-length-attribute-types.feature
+++ b/features/ALS012_Alignment-segment-start-and-length-attribute-types.feature
@@ -1,5 +1,6 @@
 @informal-proposition
 @ALS
+@GEM
 @version1
 @E00010
 

--- a/features/ALS015_Alignment-representation-zero-length-final-segment.feature
+++ b/features/ALS015_Alignment-representation-zero-length-final-segment.feature
@@ -1,5 +1,6 @@
 @implementer-agreement
 @ALS
+@GEM
 @version2
 @E00020
 Feature: ALS015 - Alignment representation zero length final segment

--- a/features/ALS016_Alignment-horizontal-segment-geometric-continuity.feature
+++ b/features/ALS016_Alignment-horizontal-segment-geometric-continuity.feature
@@ -1,5 +1,6 @@
 @industry-practice
 @ALS
+@GEM
 @version1
 
 Feature: ALS016 - Alignment horizontal segment geometric continuity

--- a/features/environment.py
+++ b/features/environment.py
@@ -43,15 +43,6 @@ def before_feature(context, feature):
         protocol_errors = protocol.enforce(convention_attrs)
         for error in protocol_errors:
             context.protocol_errors.append(error)
-        #     validation_outcome = ValidationOutcome(
-        #     outcome_code=ValidationOutcomeCode.EXECUTED,
-        #     observed=error,
-        #     expected=error,
-        #     feature=context.feature.name,
-        #     feature_version=1,
-        #     severity=OutcomeSeverity.ERROR,
-        # )
-        #     context.protocol_errors.append(validation_outcome)
     
     context.gherkin_outcomes = []
         

--- a/features/environment.py
+++ b/features/environment.py
@@ -42,17 +42,18 @@ def before_feature(context, feature):
             }
         protocol_errors = protocol.enforce(convention_attrs)
         for error in protocol_errors:
-            validation_outcome = ValidationOutcome(
-            outcome_code=ValidationOutcomeCode.EXECUTED,
-            observed=error,
-            expected=error,
-            feature=context.feature.name,
-            feature_version=1,
-            severity=OutcomeSeverity.ERROR,
-        )
-            context.protocol_errors.append(validation_outcome)
-
-    context.gherkin_outcomes = context.protocol_errors
+            context.protocol_errors.append(error)
+        #     validation_outcome = ValidationOutcome(
+        #     outcome_code=ValidationOutcomeCode.EXECUTED,
+        #     observed=error,
+        #     expected=error,
+        #     feature=context.feature.name,
+        #     feature_version=1,
+        #     severity=OutcomeSeverity.ERROR,
+        # )
+        #     context.protocol_errors.append(validation_outcome)
+    
+    context.gherkin_outcomes = []
         
 
 def before_scenario(context, scenario):
@@ -131,3 +132,7 @@ def after_feature(context, feature):
         outcomes_bytes = outcomes_json_str.encode("utf-8") 
         for formatter in filter(lambda f: hasattr(f, "embedding"), context._runner.formatters):
             formatter.embedding(mime_type="application/json", data=outcomes_bytes, target='feature', attribute_name='validation_outcomes')
+
+            # embed protocol errors
+            protocol_errors_bytes = json.dumps(context.protocol_errors).encode("utf-8")
+            formatter.embedding(mime_type="application/json", data=protocol_errors_bytes, target='feature', attribute_name='protocol_errors')

--- a/features/rule_creation_protocol/tags_hierarchy.py
+++ b/features/rule_creation_protocol/tags_hierarchy.py
@@ -1,0 +1,5 @@
+tags_hierarchy = {
+    'POS': ['LOP', 'LIP', 'GDP', 'GRD', 'ALB', 'RFT'],
+    'GEM': ['TAS', 'SWE', 'MPD', 'BRP', 'TFM', 'BBX', 'RCO', 'CPD', 'ALS'],
+    'OJP': ['LOP', 'LIP', 'GDP']
+}

--- a/features/rule_creation_protocol/validation_helper.py
+++ b/features/rule_creation_protocol/validation_helper.py
@@ -49,6 +49,7 @@ class ValidatorHelper():
             }
         # Functional part validity check
         return self.valid_functional_part(code['functional_part'])
+    
     def validate_tags(self, tags):
         if (rule_type_tags := [t for t in tags if t.lower() in ['implementer-agreement', 'informal-proposition', 'industry-practice', 'critical']]) and len(rule_type_tags) > 1: 
             return { 
@@ -62,6 +63,27 @@ class ValidatorHelper():
                 'value': current_tags,
                 'message': 'The tags must contain one tag with a reference to a valid functional part'
             }
+        
+
+        from .tags_hierarchy import tags_hierarchy
+        required_parents = {parent: False for parent in tags_hierarchy.keys()}
+
+        for tag in functional_part_tags:
+            for parent, children in tags_hierarchy.items():
+                if tag in children:
+                    required_parents[parent] = True
+        
+        missing_tags = []
+        for parent, is_present in required_parents.items():
+            if is_present and parent not in functional_part_tags:
+                missing_tags.append(parent)
+        
+        if missing_tags:
+            return {
+                'value': missing_tags,
+                'message': f"The tags {''.join(functional_part_tags)} must contain the following parent tags: {missing_tags}"
+            }
+        
         return 'passed'
     
     

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -7,7 +7,7 @@ from behave import step
 import inspect
 from operator import attrgetter
 import ast
-from validation_results import ValidationOutcome, OutcomeSeverity, ValidationOutcomeCode
+from validation_results import ValidationOutcome, OutcomeSeverity, ValidationOutcomeCode, FunctionalPart
 from behave import register_type
 
 from behave.runner import Context
@@ -104,6 +104,7 @@ def execute_step(fn):
             feature=context.feature.name,
             feature_version=misc.define_feature_version(context),
             severity=OutcomeSeverity.NOT_APPLICABLE,
+            functional_part_codes = FunctionalPart.filter_functional_part_tags(context.feature.tags),
             validation_task_id=context.validation_task_id
         )
         context.gherkin_outcomes.append(validation_outcome)
@@ -209,6 +210,7 @@ def handle_then(context, fn, **kwargs):
         feature=context.feature.name,
         feature_version=misc.define_feature_version(context),
         severity=OutcomeSeverity.EXECUTED,
+        functional_part_codes = FunctionalPart.filter_functional_part_tags(context.feature.tags),
         validation_task_id=context.validation_task_id
         )
     )
@@ -237,6 +239,7 @@ def handle_then(context, fn, **kwargs):
                     expected=expected_behave_output(context, result.expected),
                     feature=context.feature.name,
                     feature_version=misc.define_feature_version(context),
+                    functional_part_codes = FunctionalPart.filter_functional_part_tags(context.feature.tags),
                     severity=OutcomeSeverity.WARNING if any(tag.lower() == "industry-practice" for tag in context.feature.tags) else OutcomeSeverity.ERROR,
                     instance_id=safe_method_call(inst_to_display, 'id', None),
                     validation_task_id=context.validation_task_id

--- a/main.py
+++ b/main.py
@@ -128,6 +128,11 @@ def run(filename, rule_type=RuleType.ALL, with_console_output=False, execution_m
                 except KeyError:
                     el_list = []
                 for el in el_list:
+                    protocol_errors = json.loads(base64.b64decode(el.get('protocol_errors', [{}])[0].get('data', '')).decode('utf-8')) if el.get('protocol_errors') else []
+                    if protocol_errors:
+                        yield {
+                            'protocol_errors': protocol_errors,
+                        }
                     scenario_validation_outcomes = json.loads(base64.b64decode(el.get('validation_outcomes', [{}])[0].get('data', '')).decode('utf-8')) if el.get('validation_outcomes') else []
                     scenario_info = {
                         'scenario_name': el['name'],

--- a/validation_results.py
+++ b/validation_results.py
@@ -28,9 +28,9 @@ else:
 django.setup()
 
 try:
-    from apps.ifc_validation_models.models import ValidationOutcome, ModelInstance, ValidationTask
+    from apps.ifc_validation_models.models import ValidationOutcome, ModelInstance, ValidationTask, FunctionalPart
 except:
-    from ifc_validation_models.models import ValidationOutcome, ModelInstance, ValidationTask
+    from ifc_validation_models.models import ValidationOutcome, ModelInstance, ValidationTask, FunctionalPart
 
 OutcomeSeverity = ValidationOutcome.OutcomeSeverity
 ValidationOutcomeCode = ValidationOutcome.ValidationOutcomeCode


### PR DESCRIPTION
- Add missing tags
- A protocol error is now triggered when a tag is missing (e.g. a `ALS` rule without a `GEM` tag)
- Protocol errors are embedded to JSON, causing a more straightforward error message

![image](https://github.com/user-attachments/assets/7ae96f7f-9234-4739-b8c5-b7cb19f5c305)
