### PR TITLE
Separate protocol check in custom json formatter

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -42,17 +42,9 @@ def before_feature(context, feature):
             }
         protocol_errors = protocol.enforce(convention_attrs)
         for error in protocol_errors:
-            validation_outcome = ValidationOutcome(
-            outcome_code=ValidationOutcomeCode.EXECUTED,
-            observed=error,
-            expected=error,
-            feature=context.feature.name,
-            feature_version=1,
-            severity=OutcomeSeverity.ERROR,
-        )
-            context.protocol_errors.append(validation_outcome)
+            context.protocol_errors.append(error)
 
-    context.gherkin_outcomes = context.protocol_errors
+    context.gherkin_outcomes = []
         
 
 def before_scenario(context, scenario):
@@ -131,3 +123,7 @@ def after_feature(context, feature):
         outcomes_bytes = outcomes_json_str.encode("utf-8") 
         for formatter in filter(lambda f: hasattr(f, "embedding"), context._runner.formatters):
             formatter.embedding(mime_type="application/json", data=outcomes_bytes, target='feature', attribute_name='validation_outcomes')
+
+            # embed protocol errors
+            protocol_errors_bytes = json.dumps(context.protocol_errors).encode("utf-8")
+            formatter.embedding(mime_type="application/json", data=protocol_errors_bytes, target='feature', attribute_name='protocol_errors') 

--- a/main.py
+++ b/main.py
@@ -128,6 +128,11 @@ def run(filename, rule_type=RuleType.ALL, with_console_output=False, execution_m
                 except KeyError:
                     el_list = []
                 for el in el_list:
+                    protocol_errors = json.loads(base64.b64decode(el.get('protocol_errors', [{}])[0].get('data', '')).decode('utf-8')) if el.get('protocol_errors') else []
+                    if protocol_errors:
+                        yield {
+                            'protocol_errors': protocol_errors,
+                        }
                     scenario_validation_outcomes = json.loads(base64.b64decode(el.get('validation_outcomes', [{}])[0].get('data', '')).decode('utf-8')) if el.get('validation_outcomes') else []
                     scenario_info = {
                         'scenario_name': el['name'],


### PR DESCRIPTION
Remaining from https://github.com/buildingSMART/ifc-gherkin-rules/pull/291

Run protocol check separately from the main validation by integrating it into the custom JSON formatter.
I was initially adding it to the `context.gherkin_outcomes` and was running into some (small) issues with the overlap with the actual validation outcomes. It's probably better to separate this now we have our own formatter available.