### PR TITLE
IVS-315 Quadratic complexity in GEM003

### DIFF
--- a/features/GEM003_Unique-representation-identifier.feature
+++ b/features/GEM003_Unique-representation-identifier.feature
@@ -12,4 +12,4 @@ The rule verifies that Shape Representation identifier is unique within the prod
     Given Its attribute Representations
     Given its attribute RepresentationIdentifier
 
-    Then The values must be unique
+    Then The values must be unique at depth 1

--- a/features/GRF001_Identical-coordinate-operations.feature
+++ b/features/GRF001_Identical-coordinate-operations.feature
@@ -15,4 +15,4 @@ Currently, for GRF001, this is only permitted if (1) there is a single context o
     Given Its Attribute HasCoordinateOperation
     Given Its values excluding SourceCRS
     
-    Then The values must be identical at depth 1
+    Then The values must be identical at depth 2

--- a/features/steps/thens/values.py
+++ b/features/steps/thens/values.py
@@ -59,8 +59,8 @@ def step_impl(context, inst, constraint, num):
             yield ValidationOutcome(inst=inst, expected= constraint, observed = f"Not {constraint}", severity=OutcomeSeverity.ERROR)
 
 
-@gherkin_ifc.step("The values must be {constraint:unique_or_identical} at depth 1")
-def step_impl(context, inst, constraint, num=None):
+@gherkin_ifc.step("The values must be {constraint:unique_or_identical} at depth {depth_level:d}")
+def step_impl(context, inst, constraint, depth_level=None):
     if not inst:
         return
 

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import re
 from utils import misc
 from functools import wraps
 import ifcopenshell
@@ -148,9 +149,9 @@ def handle_given(context, fn, **kwargs):
             pass # (1) -> context.applicable is set within the function ; replace this with a simple True/False and set applicability here?
     else:
         context._push('attribute') # for attribute stacking
-        if 'at depth 1' in context.step.name:
-            #todo @gh develop a more standardize approach
-            context.instances = list(filter(None, map_given_state(context.instances, fn, context, depth=1, **kwargs)))
+        depth = next(map(int, re.findall('at depth (\d+)$', context.step.name)), 0)
+        if depth:
+            context.instances = list(filter(None, map_given_state(context.instances, fn, context, depth=depth, **kwargs)))
         else:
             context.instances = map_given_state(context.instances, fn, context, **kwargs)
 
@@ -167,9 +168,8 @@ def map_given_state(values, fn, context, depth=0, **kwargs):
     def should_apply(values, depth):
         if depth == 0:
             return not is_nested(values)
-        elif depth == 1:
-            return is_nested(values) and all(not is_nested(v) for v in values)
-        return False
+        else:
+            return is_nested(values) and any(should_apply(v, depth-1) for v in values)
 
     if should_apply(values, depth):
         return None if values is None else apply_operation(fn, values, context, **kwargs)
@@ -275,9 +275,8 @@ def handle_then(context, fn, **kwargs):
         def should_apply(items, depth):
             if depth == 0:
                 return not is_nested(items)
-            elif depth == 1:
-                return is_nested(items) and all(not is_nested(v) for v in items)
-            return False
+            else:
+                return is_nested(items) and any(not should_apply(v, depth-1) for v in items)
 
         if context.is_global_rule:
             return apply_then_operation(fn, [items], context, current_path=None, **kwargs)
@@ -293,7 +292,8 @@ def handle_then(context, fn, **kwargs):
     # so we take note of the outcomes that already existed. This is necessary since we accumulate
     # outcomes per feature and no longer per scenario.
     num_preexisting_outcomes = len(context.gherkin_outcomes)
-    map_then_state(instances, fn, context, depth = 1 if 'at depth 1' in context.step.name.lower() else 0, **kwargs)
+    depth = next(map(int, re.findall('at depth (\d+)$', context.step.name)), 0)
+    map_then_state(instances, fn, context, depth = depth, **kwargs)
 
     # evokes behave error
     generate_error_message(context, [gherkin_outcome for gherkin_outcome in context.gherkin_outcomes[num_preexisting_outcomes:] if gherkin_outcome.severity in [OutcomeSeverity.WARNING, OutcomeSeverity.ERROR]])

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -169,7 +169,7 @@ def map_given_state(values, fn, context, depth=0, **kwargs):
         if depth == 0:
             return not is_nested(values)
         else:
-            return is_nested(values) and any(should_apply(v, depth-1) for v in values)
+            return is_nested(values) and all(should_apply(v, depth-1) for v in values if v is not None)
 
     if should_apply(values, depth):
         return None if values is None else apply_operation(fn, values, context, **kwargs)
@@ -276,7 +276,7 @@ def handle_then(context, fn, **kwargs):
             if depth == 0:
                 return not is_nested(items)
             else:
-                return is_nested(items) and any(not should_apply(v, depth-1) for v in items)
+                return is_nested(items) and all(should_apply(v, depth-1) for v in items if v is not None)
 
         if context.is_global_rule:
             return apply_then_operation(fn, [items], context, current_path=None, **kwargs)


### PR DESCRIPTION
This must have been an old one, but this is the only case I could find where we still refer to `context.instances` in the step impl function. This causes quadratic complexity because we have then the same loop in the decorator and a loop in the impl function.

See JIRA for the test model.

This was also a nice opportunity to do some clean up.

I found out that all `values must be unique|identical` were already using the `... at depth 1` logic except for this one. So that was an opportunity to actually remove all other patterns and really require a depth specification. With the current decorator it also doesn't make sense to think about uniqueness/identical in the context of a singular element which would be how the impl function would be called without a depth specification. 

I think for the `within_model` hack we already concluded at some point that we can get rid of it now that we have the `... at depth 1` which is kind of a generalization of that. But I didn't fully remove it yet, only the reference from this impl function. 