### PR TITLE
Prevent catching intentional errors (IVS-371)

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -71,8 +71,9 @@ def after_scenario(context, scenario):
     execution_mode = context.config.userdata.get('execution_mode')
     if execution_mode and execution_mode == 'ExecutionMode.TESTING':
         if context.failed:
-            if context.step.error_message and not 'Behave errors' in context.step.error_message: #exclude behave output from exception logging
+            if context.step.error_message and not getattr(context, 'intentional_error_occured', False): #exclude behave output from exception logging
                 context.caught_exceptions.append(ExceptionSummary.from_context(context))
+                context.intentional_error_occured = False
         context.scenario_outcome_state.append((len(context.gherkin_outcomes)-1, {'scenario': context.scenario.name, 'last_step': context.scenario.steps[-1]}))
     elif execution_mode and execution_mode == 'ExecutionMode.PRODUCTION':
         if context.failed:

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -68,6 +68,7 @@ def generate_error_message(context, errors):
     """
     Function to trigger the behave error mechanism by raising an exception so that errors are printed to the console.
     """
+    context.intentional_error_occured = True
     assert not errors, "Errors occured:" + ''.join(f'\n - {error}' for error in errors)
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -109,11 +109,11 @@ def test_invocation(filename):
             print(tabulate.tabulate(table_data, headers=headers, tablefmt='fancy_grid'))
 
         if base.startswith('fail'):
-            assert len(error_outcomes) > 0 or caught_exceptions
+            assert len(error_outcomes) > 0
         elif base.startswith('pass'):
-            assert len(error_outcomes) == 0 and len(activating_outcomes) > 0
+            assert len(error_outcomes) == 0 and len(activating_outcomes) and not caught_exceptions > 0
         elif base.startswith('na'):
-            assert len(error_outcomes) == 0 and len(activating_outcomes) == 0
+            assert len(error_outcomes) == 0 and len(activating_outcomes) == 0 and not caught_exceptions
 
     if error_outcomes:
         tabulate_results = [

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -111,7 +111,7 @@ def test_invocation(filename):
         if base.startswith('fail'):
             assert len(error_outcomes) > 0
         elif base.startswith('pass'):
-            assert len(error_outcomes) == 0 and len(activating_outcomes) and not caught_exceptions > 0
+            assert len(error_outcomes) == 0 and len(activating_outcomes) and not caught_exceptions
         elif base.startswith('na'):
             assert len(error_outcomes) == 0 and len(activating_outcomes) == 0 and not caught_exceptions
 


### PR DESCRIPTION
We were catching intentional errors as unintentional exceptions due to 
https://github.com/buildingSMART/ifc-gherkin-rules/pull/329/files#diff-2c838ec4f24dc4e43b898ddaa7de4de8f6cc972099850db514753312625e105a

The two types were distinguished by the output string (i.e. if the string contained` 'Behave errors'` the error is intentional), it is probably better to store this information in the behave context instead.