### PR TITLE
IVS-469 Fix swe001 apply unit factor

### DIFF
--- a/features/rules/SWE/SWE001_Arbitrary-profile-boundary-no-self-intersections.feature
+++ b/features/rules/SWE/SWE001_Arbitrary-profile-boundary-no-self-intersections.feature
@@ -1,6 +1,6 @@
 @informal-proposition
 @SWE
-@version2
+@version3
 @E00050
 Feature: SWE001 - Arbitrary profile boundary no self-intersections
 The rule verifies that IfcArbitraryClosedProfileDefs and IfcArbitraryProfileDefWithVoids do

--- a/features/steps/thens/geometry.py
+++ b/features/steps/thens/geometry.py
@@ -145,7 +145,7 @@ def step_impl(context, inst: ifcopenshell.entity_instance, path=None, attr:str =
     """
 
     entity_contexts = ifc.recurrently_get_entity_attr(context, inst, 'IfcRepresentation', 'ContextOfItems')
-    precision = ifc.get_precision_from_contexts(entity_contexts)
+    precision = ifc.get_precision_from_contexts(entity_contexts, return_in_m=True)
 
     p = rtree.index.Property()
     p.dimension = 3


### PR DESCRIPTION
Fixes #385

Most of the comparisons between precision values happens between data read directly from the model (such as point.Coordinates for an IfcCartesianPoint instance) but if we use ifcopenshell.geom.create_shape() we either need to apply 'convert-back-units', True to the settings, or convert the precision value also to meters.