### PR TITLE
IVS-472 - Update BRP tags

### DIFF
--- a/features/rules/BRP/BRP001_Polyhedral-IfcFace-boundary-no-self-intersections.feature
+++ b/features/rules/BRP/BRP001_Polyhedral-IfcFace-boundary-no-self-intersections.feature
@@ -1,6 +1,5 @@
 @disabled
 @informal-proposition
-@GEM
 @BRP
 @version1
 @E00050

--- a/features/rules/BRP/BRP002_Single-component-in-connected-faceset.feature
+++ b/features/rules/BRP/BRP002_Single-component-in-connected-faceset.feature
@@ -1,5 +1,5 @@
 @informal-proposition
-@GEM
+@BRP
 @version2
 @E00050
 Feature: BRP002 - Single component in connected faceset

--- a/features/rules/BRP/BRP003_Planar-faces-are-planar.feature
+++ b/features/rules/BRP/BRP003_Planar-faces-are-planar.feature
@@ -1,5 +1,4 @@
 @informal-proposition
-@GEM
 @BRP
 @version2
 @E00050


### PR DESCRIPTION
See also https://github.com/buildingSMART/ifc-gherkin-rules/pull/381#discussion_r2013736678

We discussed to have one single tag per rule. This wasn’t done correctly in BRP, where GEM was included (in one case, as the only tag).
Or was this intentional / did I miss something?