### PR TITLE
Further sanitizing JSON infinite values 

### DIFF
--- a/features/steps/utils/geometry.py
+++ b/features/steps/utils/geometry.py
@@ -282,18 +282,27 @@ class AlignmentSegmentContinuityCalculation:
         self.following_start_point = (s0, s1)
 
     def _calculate_directions(self) -> None:
+        def _safe_slope(run: float, rise: float, eps: float = GEOM_TOLERANCE) -> float:
+            """
+            Returns rise/run unless run is near zero, in which case returns ±inf.
+            Prevents division-by-zero in gradient calculations.
+            """
+            if abs(run) < eps:                 
+                return math.copysign(math.inf, rise)  
+            return rise / run
+        
         current_end_transform = evaluate_segment(segment=self.segment_to_analyze, dist_along=self._get_u_at_end())
         following_start_transform = evaluate_segment(segment=self.following_segment, dist_along=0.0)
 
         current_i = current_end_transform[0][0]
         current_j = current_end_transform[1][0]
         self.current_end_direction = math.atan2(current_j, current_i)
-        self.current_end_gradient = float(current_j / current_i)
+        self.current_end_gradient = _safe_slope(current_i, current_j)
 
         following_i = following_start_transform[0][0]
         following_j = following_start_transform[1][0]
         self.following_start_direction = math.atan2(following_j, following_i)
-        self.following_start_gradient = float(following_j / following_i)
+        self.current_end_gradient = _safe_slope(current_i, current_j)
 
     def run(self) -> None:
         """

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -8,6 +8,7 @@ from behave import step
 import inspect
 from operator import attrgetter
 import ast
+import numpy as np
 from validation_results import ValidationOutcome, OutcomeSeverity, ValidationOutcomeCode
 
 from behave.runner import Context
@@ -329,13 +330,26 @@ def expected_behave_output(context: Context, data: Any, is_observed : bool = Fal
         except (ValueError, SyntaxError):
             pass
     
-    def ensure_finite_numbers(obj):
-        if isinstance(obj, float) and not math.isfinite(obj):
-            return None                
+    def sanitise_for_json(obj):
+        """
+        Replaces NaN with None, ±inf with strings, and converts NumPy arrays
+        to lists, making the object safe for JSON serialization.
+        """
+        if isinstance(obj, (float, np.floating)):
+            x = float(obj)
+            if math.isnan(x):
+                return None # null in db                     
+            if math.isinf(x):
+                return "infinity" if x > 0 else "-infinity"
+            return obj    
+                             
+        if isinstance(obj, np.ndarray):
+            return sanitise_for_json(obj.tolist()) # Walk through nested lists (to.list()) so inf/nan inside get fixed.
         if isinstance(obj, dict):
-            return {k: ensure_finite_numbers(v) for k, v in obj.items()}
+            return {k: sanitise_for_json(v) for k, v in obj.items()}
         if isinstance(obj, (list, tuple)):
-            return [ensure_finite_numbers(v) for v in obj]
+            return [sanitise_for_json(v) for v in obj]
+
         return obj
 
     match data:
@@ -362,7 +376,7 @@ def expected_behave_output(context: Context, data: Any, is_observed : bool = Fal
             return {'instance': display_entity_instance(data)}
         case dict():
             # mostly for the pse001 rule, which already yields dicts
-            return ensure_finite_numbers(data)
+            return sanitise_for_json(data)
         case set(): # object of type set is not JSONserializable
             return tuple(data)
         case _:


### PR DESCRIPTION
See also comment https://github.com/buildingSMART/ifc-gherkin-rules/pull/422/files#r2173636729

Building some additional safety mechanisms to prevent future IVS-550-like errors 

## New function & test cases
```
def sanitise_for_json(obj):
    if isinstance(obj, (float, np.floating)):
        x = float(obj)
        if math.isnan(x):
            return None # null in db                     
        if math.isinf(x):
            return "infinity" if x > 0 else "-infinity"
        return obj    
                            
    if isinstance(obj, np.ndarray):
        return sanitise_for_json(obj.tolist()) # We walk walk through nested lists (to.list()) so inf/nan inside get fixed.
    if isinstance(obj, dict):
        return {k: sanitise_for_json(v) for k, v in obj.items()}
    if isinstance(obj, (list, tuple)):
        return [sanitise_for_json(v) for v in obj]

ratio = np.arange(9, dtype=float).reshape(3, 3) / np.zeros(3)[:, None] 

data = {
    "finite"  : 3.14,
    "pos_inf" : float("inf"),
    "neg_inf" : -np.float64("inf"),
    "inf_rise": math.copysign(math.inf, 7.5),
    "array": np.array([1, 2, np.inf, -np.inf, np.nan], dtype=np.float64), #  Array full of edge cases
    "not_num" : float("nan"),
    "ratio": ratio,
    "nested"  : [1, 2, float("nan"), np.float32("inf")],
}

clean = sanitise_for_json(data)
print(json.dumps(clean, indent=2))
```

--- 
## Testing result

```
{
  "finite": 3.14,
  "pos_inf": "infinity",
  "neg_inf": "-infinity",
  "inf_rise": "infinity",
  "array": [1.0,2.0,"infinity","-infinity",null
  ],
  "not_num": null,
  "ratio": [
    [ null,"infinity",infinity"
    ],
    [ "infinity","infinity", "infinity"
    ],
    [ "infinity", "infinity", "infinity"]
  ],
  "nested": [null, null, null, "infinity"]
} 

```