### PR TITLE
Update GRF007_valid-vertical-datum-crs-type.feature

### DIFF
--- a/features/rules/GRF/GRF007_valid-vertical-datum-crs-type.feature
+++ b/features/rules/GRF/GRF007_valid-vertical-datum-crs-type.feature
@@ -7,7 +7,7 @@ The rule verifies that any coordinate reference system (CRS) assigned as a verti
 https://pyproj4.github.io/pyproj/stable/api/crs/crs.html
 
 
-  Scenario: WKT specification for missing ESPG in the name
+  Scenario: WKT specification for missing EPSG in the name
 
       Given A model with Schema 'IFC4' or 'IFC4.3'
       Given an .IfcProjectedCRS.


### PR DESCRIPTION
In a PR because of the complications of merging IVS-520. This change will be a nice test case for when the new ifcopenshell build is ready. 