### PR TITLE
IVS-639 Fix precision

### DIFF
--- a/features/rules/BRP/BRP001_Polyhedral-IfcFace-boundary-no-self-intersections.feature
+++ b/features/rules/BRP/BRP001_Polyhedral-IfcFace-boundary-no-self-intersections.feature
@@ -1,7 +1,7 @@
 @disabled
 @informal-proposition
 @BRP
-@version1
+@version2
 @E00050
 Feature: BRP001 - Polyhedral IfcFace boundary no self-intersections
 The rule verifies that IfcFace instances do not have any self-intersections in their boundaries. 

--- a/features/rules/SWE/SWE001_Arbitrary-profile-boundary-no-self-intersections.feature
+++ b/features/rules/SWE/SWE001_Arbitrary-profile-boundary-no-self-intersections.feature
@@ -1,6 +1,6 @@
 @informal-proposition
 @SWE
-@version3
+@version4
 @E00050
 Feature: SWE001 - Arbitrary profile boundary no self-intersections
 The rule verifies that IfcArbitraryClosedProfileDefs and IfcArbitraryProfileDefWithVoids do

--- a/features/rules/TAS/TAS001_Polygonal-face-boundary-no-self-intersections.feature
+++ b/features/rules/TAS/TAS001_Polygonal-face-boundary-no-self-intersections.feature
@@ -1,7 +1,7 @@
 @disabled
 @informal-proposition
 @TAS
-@version1
+@version2
 @E00050
 Feature: TAS001 - Polygonal face boundary no self-intersections
 The rule verifies that IfcFace instances do not have any self-intersections in their boundaries. 

--- a/features/steps/utils/ifc.py
+++ b/features/steps/utils/ifc.py
@@ -32,13 +32,9 @@ def get_precision_from_contexts(entity_contexts : typing.Sequence[ifcopenshell.e
     else:
         unit_scale = 1.
     for entity_context in entity_contexts:
-        if entity_context.is_a('IfcGeometricRepresentationSubContext'):
-            precision = get_precision_from_contexts([entity_context.ParentContext])
-        elif entity_context.is_a('IfcGeometricRepresentationContext') and entity_context.Precision:
-            return entity_context.Precision * unit_scale
-        else:
-            continue
-        precisions.append(precision)
+        if entity_context.Precision is not None:
+            precision = entity_context.Precision * unit_scale
+            precisions.append(precision)
     if not precisions:
         return default_precision
     return func_to_return(precisions)


### PR DESCRIPTION
I don't know why the code here was so convoluted (probably because of some confusion about derived attributes; subcontext.Precision is an attribute redeclared as derived, but this is supported in ifcopenshell, maybe not when the project first started though....)

Problem was that in one of the branch the unit factor was not applied :(

Rule bumped for all code that uses `return_in_m=True`.