### PR TITLE
Keep display instance indices in sync (IVS-702)

### DIFF
--- a/features/rules/IFC/IFC105_Resource-entities-need-to-be-referenced-by-rooted-entity.feature
+++ b/features/rules/IFC/IFC105_Resource-entities-need-to-be-referenced-by-rooted-entity.feature
@@ -11,5 +11,5 @@ The inverse attributes that are followed are: StyledByItem HasCoordinateOperatio
 
     Given a traversal over the full model originating from subtypes of .IfcRoot.
     Given an .entity instance.
-    Given [its entity type] ^is not^ 'IfcRoot'
+    Given [its entity type] ^is not^ 'IfcRoot' ^including subtypes^
     Then it must be referenced by an entity instance inheriting from IfcRoot directly or indirectly

--- a/features/steps/validation_handling.py
+++ b/features/steps/validation_handling.py
@@ -248,9 +248,6 @@ def handle_then(context, fn, **kwargs):
                 if 'npath' in inspect.getargs(fn.__code__).args:
                     kwargs = kwargs | {'npath': current_path}
             top_level_index = current_path[0] if current_path else None
-            max_index = len(current_path) - 1
-            if top_level_index > max_index:
-                top_level_index = max_index
             activation_inst = inst if not current_path or activation_instances[top_level_index] is None else activation_instances[top_level_index]
             # TODO: refactor into a more general solution that works for all rules
             if context.is_global_rule and (


### PR DESCRIPTION
Fixes https://github.com/buildingSMART/ifc-gherkin-rules/issues/480

1. `... ^including subtypes^` does not really affect rule execution as the statement is redundant: The traversal starts from IfcRoot, so everything that is IfcRoot is guaranteed not to fail this rule. But the current way the statement is written is silly because IfcRoot is abstract and without `including subtypes` it doesn't take into account inheritance. We can do a version bump if you guys feel it's apt, I'm ambivalent.

2. The real issue is this unresolved conversation here https://github.com/buildingSMART/ifc-gherkin-rules/pull/471#discussion_r2567647559

`current_path = [a,b,c]` is to be applied as `context.instances[a][b][c]` to get to the relevant instance that the rule is being executed upon. For context.instances you should actually read `misc.getstacktree()[n][a][b][c]` i.e the index can be applied at every layer, but previous layers (=higher index) might not have yet the full depth as we have in current_path. The first (=-1) layer (afaict) will always be a flat list of instances, so therefore `top_level_index := current_path[0]` is applied to `activation_instances` which is `misc.get_stack_tree(context)[-1]`

Now where this went wrong in some rules is that if we have midway a statement `Given an IfcSomething` then this breaks the correspondence between layers in the stack, because `Given an IfcSomething` completely overwrites the values for that current layer, it doesn't derive from the previous layer.