### PR TITLE
perf: cache attribute-matrix loader (OJP001 per-instance glob+CSV)

### DIFF
--- a/features/steps/thens/attributes.py
+++ b/features/steps/thens/attributes.py
@@ -7,10 +7,14 @@ from validation_handling import gherkin_ifc
 
 from . import ValidationOutcome, OutcomeSeverity
 
+# Loaded once (matrices are static per run); load_attribute_matrix is also cached.
+_related_attr_matrix = system.load_attribute_matrix("related_entity_attributes.csv")
+_relating_attr_matrix = system.load_attribute_matrix("relating_entity_attributes.csv")
+
+
 @gherkin_ifc.step("The {entity} attribute must point to the {other_entity} of the container element established with {relationship} relationship")
 def step_impl(context, inst, entity, other_entity, relationship):
-    related_attr_matrix, relating_attr_matrix = system.load_attribute_matrix(
-        "related_entity_attributes.csv"), system.load_attribute_matrix("relating_entity_attributes.csv")
+    related_attr_matrix, relating_attr_matrix = _related_attr_matrix, _relating_attr_matrix
     relationship_relating_attr = relating_attr_matrix.get(relationship)
     relationship_related_attr = related_attr_matrix.get(relationship)
 

--- a/features/steps/utils/system.py
+++ b/features/steps/utils/system.py
@@ -1,4 +1,5 @@
 import csv
+import functools
 import glob
 import os
 
@@ -6,7 +7,11 @@ from .misc import do_try
 from pathlib import Path
 
 
+@functools.lru_cache(maxsize=None)
 def get_abs_path(rel_path):
+    # The resources/** tree does not change during a run, so the (recursive) glob
+    # result is stable. Without caching this walks the filesystem on every call —
+    # which is per-instance for rules that resolve attribute matrices in a Then.
     dir_name = os.path.dirname(__file__)
     parent_path = Path(dir_name).parent.parent
     csv_path = do_try(lambda: glob.glob(os.path.join(parent_path, rel_path), recursive=True)[0])
@@ -21,7 +26,9 @@ def get_csv(abs_path, return_type='list', newline='', delimiter=',', quotechar='
             reader = csv.reader(csvfile, delimiter=delimiter, quotechar=quotechar)
         return [row for row in reader]
 
+@functools.lru_cache(maxsize=None)
 def load_attribute_matrix(table, base_folder = "resources/**/"):
+    # Cached: the matrix CSVs are static per run and read-only at the call sites.
     filename = get_abs_path(f"{base_folder}{table}")
     # filename = f"{base_path}{table}"
 


### PR DESCRIPTION
Caches `system.load_attribute_matrix()`, which runs a recursive `glob('resources/**')` + CSV open/parse on every call.

### Problem
`thens/attributes.py` calls `load_attribute_matrix` **twice** inside the per-instance `Then` *"The {entity} attribute must point to the {other_entity} of the container element established with {relationship} relationship"* (used by **OJP001**) — i.e. two filesystem tree-walks + two CSV parses **per aggregated element**.

Measured: one uncached glob+parse ~1.55 ms, cached ~0.045 us. On a 78 MB model that `Then` processed ~8k elements (~25 s of pure glob+CSV, down to ~53 ms after caching). On a 700 MB model OJP001 was the slowest rule by ~2x with this as a large component.

### Fix
The matrix CSVs are static and read-only at the call sites, so memoize the loader and the glob path resolver (`functools.lru_cache`), and hoist the two loads in `attributes.py` to module level (as `givens/relationships.py` already does). No behavioural change (identical outcomes).

Profiling write-up in #527 (follow-up comment).